### PR TITLE
Add new 3.6.2 folder

### DIFF
--- a/3.6.2/README.md
+++ b/3.6.2/README.md
@@ -1,0 +1,414 @@
+   * [Installation Overview](#installation-overview)
+      * [About the Installer](#about-the-installer)
+      * [Install vs Upgrade](#Install-vs-Upgrade)
+      * [Prerequisites](#prerequisites)
+   * [Quickstart Install](#quickstart-install)
+   * [Airgapped Installation Options](#airgapped-installation-options)
+      * [Airgapped with Multi-Homed Installation Machine](#airgapped-with-multi-homed-installation-machine)
+      * [Full Airgap Install](#full-airgap-install)
+      * [Updating Vulnerability Feed](#updating-vulnerability-feed)
+   * [Output](#output)
+   * [Additional Installer Resources](#Additional-Installer-Resources)
+      * [Frequently Used Options](advanced.md)
+      * [Configuration Parameters](configuration_parameters.md)
+      * [Example values.yaml](examples/README.md)
+      * [Agent Install](agent_install.md)
+      * [Permissions](permissions.md)
+      * [Upgrade notes](upgrade_notes.md)
+
+# Installation Overview
+
+To install, you will download the installer binary and a values.yaml file, provide a few basic parameters, and launch the Installer. In a normal installation, the rest is automatically configured and deployed.
+
+You can perform a quick install if your environment has access to the internet, or a partial or full airgapped installation, as needed. Each is described below.
+
+## About the Installer
+
+The Sysdig Installer tool is a binary containing a collection of scripts that help automate the on-premises deployment of the Sysdig platform (Sysdig Monitor and/or Sysdig Secure), for environments using Kubernetes or OpenShift. Use the Installer to install or upgrade your Sysdig platform. It is recommended as a replacement for the earlier Kubernetes manual installation and upgrade procedures.
+
+## Install vs Upgrade
+
+With Sysdig Platform 3.5.0, the installer has been simplified from previous versions. Upgrade differs from Install in that you run an `installer diff` to discover the differences between the old and new versions and then `installer deploy` for the new version.
+
+If you are installing the Sysdig Platform for the first time, ignore the *ForUpgradeOnly* step in the process. If you are upgrading, See [Upgrade notes](upgrade_notes.md) for release-specific upgrade information.
+
+> **Note**
+>
+> For Sysdig TAMs: If you are upgrading from much older versions and do not find that documentation in the GitHub folders yet, see our internal site <https://github-push-sysdigdocs.netlify.app/en/on-prem-deploy-nov_4_2020.html>.
+
+## Prerequisites
+
+### Requirements for Installation Machine with Internet Access
+
+- kubectl or oc binary
+- A domain name you are in control of.
+
+### Additional Requirements for Airgapped Environments
+
+- Edited sysdig-chart/values.yaml, with airgap registry details updated
+- Network and authenticated access to the private registry
+- Network access to quay.io
+
+### Access Requirements
+
+- Sysdig license key (Monitor and/or Secure)
+- Quay pull secret
+
+### Storage Requirements
+
+You may use dynamic or static storage on a variety of platforms to store the Sysdig platform components (stateful sets). Different configuration parameters and values are used during the install, depending on which scenario you have.
+
+**Use Case 1: Default, undefined (AWS/GKE)**
+
+If you will use dynamic storage on AWS or GKE and haven't configured any storage class there yet, then the Quick Install streamlines the process for you.
+
+-   `storageclassProvision``er:` Enter `aws` or `gke`. The installer will create the appropriate storage class and then use it for all the Sysdig platform stateful sets.
+
+-   `storageclassName`: Leave empty.
+
+**Use Case 2: Dynamic, predefined**
+
+It is also possible that you are using dynamic storage but have already created storage classes there. This dynamic storage could be AWS, GKE, or any other functioning dynamic storage you use.  In this case, you would enter: 
+
+-   `storageclassProvisioner`: Leave empty; anything put here would be ignored.
+
+-   `storageclass``Name`: Provide the name of the pre-configured storage class you want to use. The installer will use this storage class for all the Sysdig platform stateful sets.
+
+**Use Case 3: Static Storage**
+
+In cases where dynamic storage is not available, you can use static storage for the Sysdig stateful sets. In this case, you would use:
+
+-   `storageclassProvisioner`: Enter `hostpath`, then define the nodes for the four main Sysdig components: ElasticSearch, Cassandra, MySQL, and Postgres.storageclassProvisioner
+
+-   See [Advanced Configurations](advanced.md#use-hostpath-for-static-storage-of-sysdig-components) for details.
+
+# Quickstart Install
+
+This install assumes the Kubernetes cluster has network access to pull images from quay.io.
+
+1.  Have your Sysdig Technical Account Manager download the installer binary that matches your distribution.
+
+2.  **For Upgrades Only:** Preparing values.yaml
+
+    -  Option1: Use the previous values.yaml used to install your current version (recommended)
+    -  Option2: If you dont have a copy of previous values.yaml, use Installer's import function:
+          ```bash
+         ./installer-image import -n <namespace> --certs-directory certs -o values.yaml
+          ```
+          > **Note**
+          >
+          > If you will be editing for an OpenShift installation and want to review a sample, see openshift-with-hostpath [values.yaml](examples/openshift-with-hostpath/values.yaml). 
+3. Edit the following values:
+
+    -   [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size defines CPU, Memory, Disk, and Replicas. Valid options are: small, medium and large
+
+    -   [`quaypullsecret`](configuration_parameters.md#quaypullsecret): quay.io provided with your Sysdig purchase confirmation mail
+
+    -   [`storageClassProvider`](configuration_parameters.md#storageClassProvider): Review Storage Requirements, above. If you have the default use case, enter `aws` or `gke` in the `storageClassProvisioner` field. Otherwise, refer to Use Case 2 or 3.
+
+    -   [`sysdig.license`](configuration_parameters.md#sysdiglicense): Sysdig license key provided with your Sysdig purchase confirmation mail
+
+    -   [`sysdig.dnsName`](configuration_parameters.md#sysdigdnsName): The domain name the Sysdig APIs will be served on. Note that the master node may not be used as the DNS name when using hostNetwork mode.
+
+    -   [`sysdig.collector.dnsName`](configuration_parameters.md#sysdigcollectordnsName): **(OpenShift installs only)** Domain name the Sysdig collector will be served on. When not configured it defaults to whatever is configured for sysdig.dnsName. Note that the master node may not be used as the DNS name when using hostNetwork mode.
+
+    -   [`deployment`](configuration_parameters.md#deployment): **(OpenShift installs only)** Add `deployment: openshift` to the root of the `values.yaml` file.
+
+    -   [`sysdig.ingressNetworking`](configuration_parameters.md#sysdigingressnetworking): The networking construct used to expose the Sysdig API and collector.Options are:
+
+        -   **hostnetwork:** sets the hostnetworking in the ingress daemonset and opens host ports for api and collector. This does not create a Kubernetes service.
+
+        -   **loadbalancer:** creates a service of type loadbalancer and expects that your Kubernetes cluster can provision a load balancer with your cloud provider.
+
+        -   **nodeport:** creates a service of type nodeport.The node ports can be customized with:
+
+            -   `sysdig.ingressNetworkingInsecureApiNodePort`
+
+            -   `sysdig.ingressNetworkingApiNodePort`
+
+            -    `sysdig.ingressNetworkingCollectorNodePort`
+
+            When not configured, `sysdig.ingressNetworking` defaults to `hostnetwork`.
+
+            > **Note**
+            >
+            > If doing an airgapped install, you would also edit the following values:
+
+    -   [`airgapped_registry_name`](configuration_parameters.md#airgapped_registry_name): The URL of the airgapped (internal) docker registry. This URL is used for installations where the Kubernetes cluster can not pull images directly from Quay
+
+    -   [`airgapped_repository_prefix`](configuration_parameters.md#airgapped_repository_prefix): This defines custom repository prefix for airgapped\_registry. Tags and pushes images as `airgapped_registry_name/airgapped_repository_prefix``/image_name:tag`
+
+    -   [`airgapped_registry_password`](configuration_parameters.md#airgapped_registry_password): The password for the configured airgapped\_registry\_username. Ignore this parameter if the registry does not require authentication.
+
+    -   [`airgapped_registry_username`](configuration_parameters.md#airgapped_registry_username): The username for the configured airgapped\_registry\_name. Ignore this parameter if the registry does not require authentication.
+
+4.   **[For Upgrades Only]** Generate and review the diff of changes the installer is about to introduce:
+        ```bash
+        ./installer diff
+        ```
+        This will generate the differences between the installed environment and the upgrade version. The changes will be displayed in your terminal.
+        If you want to override a change, based on your environment's custom settings, then contact Sysdig Support for assistance.
+5. Run the installer:
+    ```bash
+    ./installer deploy
+    ``` 
+6. See [*Output*](#output) (below) to finish.
+
+    > **Note**
+    >
+    > Save the `values.yaml `file in a secure location; it will be used for future upgrades.
+    >
+    > There will also be a generated directory containing various Kubernetes configuration `yaml` files that were applied by the Installer against your cluster. It is not necessary to keep the generated directory, as the Installer can regenerate it consistently with the same `values.yaml `file.
+
+# Airgapped Installation Options
+
+The Installer can be used to install in airgapped environments, either with
+a multi-homed installation machine that has internet access, or in an
+environment with no internet access.
+
+## Airgapped with Multi-Homed Installation Machine
+
+This assumes a private docker registry is used and the installation machine has
+network access to pull from quay.io and push images to the private registry.
+
+The Prerequisites and workflow are the same as in the Quickstart Install, with
+the following exceptions:
+
+- In step 2, add the airgap registry information.
+- After step 3, make the installer push sysdig images to the airgapped registry by running:
+    ```bash
+    ./installer airgap
+    ```
+    That will pull all the images into `images_archive` directory as `tar` files and push them to the airgapped registry
+- Run the Installer.
+-   If you are upgrading, run the diff as directed in Step 4.
+    ```bash
+    ./installer deploy
+    ```
+
+## Full Airgap Install
+
+This assumes a private docker registry is used and the installation machine
+does not have network access to pull from quay.io, but can push images to the
+private registry.
+
+In this situation, a machine with network access (called the “jump machine”)
+will pull an image containing a self-extracting tarball which can be copied to
+the installation machine.
+
+### Access Requirements
+-   Sysdig license key (Monitor and/or Secure) 
+-   Quay pull secret
+-   Anchore license file (if Sysdig Secure is licensed)
+
+### Requirements for jump machine
+
+- Network access to quay.io
+- Docker
+- [jq](https://stedolan.github.io/jq/)
+
+### Requirements for installation machine
+
+- Network access to Kubernetes cluster
+- Docker
+- Network and authenticated access to the private registry
+- Edited sysdig-chart/values.yaml, with airgap registry details updated
+- **Host Disk Space Requirements:** `/tmp `\> 4 GB; directory from which the installer is run \>8GB; and `/var/lib/docker `\> 4GB.
+
+    > **NOTE:**
+    >
+    >The environment variable `TMPDIR` can be used to override the` /tmp` directory.
+
+### Docker Log In to quay.io
+
+Retrieve Quay username and password from Quay pull secret and login using credentials.
+   
+```bash
+AUTH=$(echo REPLACE_WITH_quaypullsecret | base64 --decode | jq -r '.auths."quay.io".auth'| base64 --decode)
+QUAY_USERNAME=${AUTH%:*}
+QUAY_PASSWORD=${AUTH#*:}
+docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io 
+```
+
+### Workflow
+
+#### On the Jump Machine
+
+1. Follow the Docker Log In to quay.io steps, above.
+2. Pull the image containing the self-extracting tar:
+      ```bash
+      docker pull quay.io/sysdig/installer:3.6.2-1-uber
+      ```
+3. Extract the tarball:
+      ```bash
+      docker create --name uber_image quay.io/sysdig/installer:3.6.2-1-uber
+      docker cp uber_image:/sysdig_installer.tar.gz .
+      docker rm uber_image
+      ```
+4. Copy the tarball to the installation machine.
+
+#### On the Installation Machine:
+1. Copy the current version sysdig-chart/values.yaml to your working directory.
+      ```bash
+      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.2/values.yaml
+      ```
+2. Edit the following values:
+      - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size
+        defines CPU, Memory, Disk, and Replicas. Valid options are: small, medium and
+        large
+      - [`quaypullsecret`](configuration_parameters.md#quaypullsecret): quay.io provided with
+        your Sysdig purchase confirmation mail
+      - [`storageClassProvider`](configuration_parameters.md#storageClassProvider): Review Storage Requirements, above. If you have the default use case, enter `aws` or `gke` in the `storageClassProvisioner` field. Otherwise, refer to Use Case 2 or 3.
+      - [`sysdig.license`](configuration_parameters.md#sysdiglicense): Sysdig license key
+        provided with your Sysdig purchase confirmation mail
+      - [`sysdig.dnsName`](configuration_parameters.md#sysdigdnsName): The domain name the Sysdig APIs will be served on. Note that the master node may not be used as the DNS name when using hostNetwork mode.
+      - [`sysdig.collector.dnsName`](configuration_parameters.md#sysdigcollectordnsName):
+        **(OpenShift installs only)** Domain name the Sysdig collector will be served on. When not configured it defaults to whatever is configured for sysdig.dnsName. Note that the master node may not be used as the DNS name when using hostNetwork mode.
+      - [`deployment`](configuration_parameters.md#deployment): **(OpenShift installs only)** Add `deployment: openshift` to the root of the `values.yaml` file.
+      - [`sysdig.ingressNetworking`](configuration_parameters.md#sysdigingressnetworking):
+        The networking construct used to expose the Sysdig API and collector. Options
+        are:
+        - hostnetwork: sets the hostnetworking in the ingress daemonset and opens
+          host ports for api and collector. This does not create a Kubernetes service.
+        - loadbalancer: creates a service of type loadbalancer and expects that
+          your Kubernetes cluster can provision a load balancer with your cloud provider.
+        - nodeport: creates a service of type nodeport. The node ports can be
+          customized with:
+          ```yaml
+          sysdig:
+            ingressNetworkingInsecureApiNodePort: 30001
+            ingressNetworkingApiNodePort: 30002
+            ingressNetworkingCollectorNodePort: 30002
+          ```
+      - [`airgapped_registry_name`](configuration_parameters.md#airgapped_registry_name):
+        The URL of the airgapped (internal) docker registry. This URL is used for
+        installations where the Kubernetes cluster can not pull images directly from
+        Quay.
+      - [`airgapped_repository_prefix`](configuration_parameters.md#airgapped_repository_prefix):
+          This defines custom repository prefix for airgapped_registry.
+          Tags and pushes images as airgapped_registry_name/airgapped_repository_prefix/image_name:tag
+      - [`airgapped_registry_password`](configuration_parameters.md#airgapped_registry_password):
+        The password for the configured airgapped_registry_username. Ignore this
+        parameter if the registry does not require authentication.
+      - [`airgapped_registry_username`](configuration_parameters.md#airgapped_registry_username):
+        The username for the configured airgapped_registry_name. Ignore this
+        parameter if the registry does not require authentication.
+3. Copy the tarball file to the directory where you have your values.yaml file.
+4. Run:
+    ```bash
+    installer airgap --tar-file sysdig_installer.tar.gz
+    ```
+    > **Note:**
+    >
+    >The above step will extract the images into `images_archive` directory relative to where the installer was run and push the images to the airgapped_registry
+
+5.  **[For Upgrades Only]** Generate and review the diff of changes the installer is about to introduce:
+
+    ```bash
+    ./installer diff
+    ```
+
+    This will generate the differences between the installed environment and the upgrade version. The changes will be displayed in your terminal.
+
+    If you want to override a change, based on your environment's custom settings, then contact Sysdig Support for assistance.
+
+6. Run the Installer:
+      ```bash
+      ./installer deploy
+      ```
+7. On successful run of Installer towards the end of your terminal you should
+  see the below:
+
+      ```
+      All Pods Ready.....Continuing
+      Congratulations, your Sysdig installation was successful!
+      You can now login to the UI at "https://awesome-domain.com:443" with:
+
+      username: "configured-username@awesome-domain.com"
+      password: "awesome-password"
+      ```
+
+> **NOTE**: 
+>
+> Save the values.yaml file in a secure location; it will be used for future upgrades. 
+>
+> There will also be a generated directory containing various Kubernetes configuration yaml files which were applied by Installer against
+your cluster. It is not necessary to keep the generated directory, as the Installer can regenerate is consistently with the same values.yaml file.
+
+### Updating Vulnerability Feed
+
+> **NOTE:** 
+>
+> Sysdig Secure users who install in an airgapped environment do not have internet access to the continuous checks of vulnerability databases that are used in image scanning. (See also: [/document/preview/117822\#UUIDc24a6ed8cdde754219092e4b32b6fd79](file:////document/preview/117822#UUIDc24a6ed8cdde754219092e4b32b6fd79).)How Sysdig Image Scanning Works
+
+As of **installer version 3.2.0-9**, airgapped environments can also receive periodic vulnerability database updates.
+
+When you install with the \"`airgapped_`\" parameters enabled (see [/document/preview/206196\#UUIDc198e7424136aa205f91d28f1495bfaf](file:////document/preview/206196#UUIDc198e7424136aa205f91d28f1495bfaf) instructions), the installer will automatically push the latest vulnerability database to your environment. Follow the steps below to reinstall/refresh the vuln db, or use the script and chron job to schedule automated updates (daily, weekly, etc.).Full Airgap Install
+
+To automatically update the vulnerability database, you can:
+
+1. Download the image file [quay.io/sysdig/vuln-feed-database:latest](https://quay.io/sysdig/vulnfeeddatabase:latest) from the Sysdig registry to the jump box server and save it locally.
+2. Move the file from the jump box server to the airgapped environment (if needed)
+3. Load the image file and push it to the airgapped image registry.
+4. Restart the pod `sysdigcloud-feeds-db`
+5. Restart the pod `feeds-api`
+
+The following script (`feeds_database_update.sh`) performs the five steps:
+
+```bash
+    #!/bin/bash
+    QUAY_USERNAME="<change_me>"
+    QUAY_PASSWORD="<change_me>"
+
+    # Download image
+    docker login quay.io/sysdig -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
+    docker image pull quay.io/sysdig/vuln-feed-database:latest
+    # Save image
+    docker image save quay.io/sysdig/vuln-feed-database:latest -o vuln-feed-database.tar
+    # Optionally move image
+    mv vuln-feed-database.tar /var/shared-folder
+    # Load image remotely
+    ssh -t user@airgapped-host "docker image load -i /var/shared-folder/vuln-feed-database.tar"
+    # Push image remotely
+    ssh -t user@airgapped-host "docker tag vuln-feed-database:latest airgapped-registry/vuln-feed-database:latest"
+    ssh -t user@airgapped-host "docker image push airgapped-registry/vuln-feed-database:latest"
+    # Restart database pod
+    ssh -t user@airgapped-host "kubectl -n sysdigcloud scale deploy sysdigcloud-feeds-db --replicas=0"
+    ssh -t user@airgapped-host "kubectl -n sysdigcloud scale deploy sysdigcloud-feeds-db --replicas=1"
+    # Restart feeds-api pod
+    ssh -t user@airgapped-host "kubectl -n sysdigcloud scale deploy sysdigcloud-feeds-api --replicas=0"
+    ssh -t user@airgapped-host "kubectl -n sysdigcloud scale deploy sysdigcloud-feeds-api --replicas=1"
+```
+Schedule a chron job to run the script on a chosen schedule (e.g. every day):
+
+    0 8 * * * feeds-database-update.sh >/dev/null 2>&1
+
+# Output
+
+A successful installation should display output in the terminal such as:
+
+    All Pods Ready.....Continuing
+    Congratulations, your Sysdig installation was successful!
+    You can now login to the UI at "https://awesome-domain.com:443" with:
+
+    username: "configured-username@awesome-domain.com"
+    password: "awesome-password"
+
+There will also be a generated directory containing various Kubernetes configuration `yaml` files which were applied by installer against your cluster. It is not necessary to keep the generated directory, as the installer can regenerate consistently with the same `values.yaml` file.
+
+# Additional Installer Resources
+
+- See [Release Notes](release_notes.md) for upgrade matrix, supported platforms & link to full feature notes
+
+- See [Upgrade notes](upgrade_notes.md) for release-specific upgrade information
+
+- See [Frequently Used Options](advanced.md) for additional configurations such as static storage and patching
+
+- See [configuration_parameters.md](configuration_parameters.md) for all the configuration parameters available, as well as their definitions, values, and examples
+
+- See [Examples](examples/README.md) of single-node, openshift... values.yaml
+
+- See [Agent Install](agent_install.md) for Installer agent install
+
+- See [Permissions](permissions.md) for running the Installer
+ 

--- a/3.6.2/advanced.md
+++ b/3.6.2/advanced.md
@@ -1,0 +1,308 @@
+# Advanced Configuration
+
+## Table of Contents  
+   * [Upgrade License](#upgrade-license)
+   * [SMTP Configs for Email Notifications](#smtp-configs-for-email-notifications)
+   * [Configure AWS Credentials Using the Installer](#configure-aws-credentials-using-the-installer)
+   * [Use hostPath for Static Storage of Sysdig Components](#use-hostpath-for-static-storage-of-sysdig-components)
+     * [Parameters](#parameters)
+     * [Example](#example)
+   * [Run Only Sysdig Pods on a Node Using Taints and Tolerations](#run-only-sysdig-pods-on-a-node-using-taints-and-tolerations)
+   * [Replace a Self-Signed Cert with Custom Cert](#replace-a-self-signed-cert-with-custom-cert)
+   * [Optional: Custom Self-Signed Certificate](#optional-custom-self-signed-certificate)
+   * [Patching Process](#patching-process)
+   
+## Upgrade License
+
+On-premises environments may require a license upgrade to renew, extend an expiration date, enable new features, add a service (Sysdig Secure), or change the number of licensed agents.
+
+- set [sysdig.license](configuration_parameters.md#sysdiglicense) in values.yaml
+```yaml
+sysdig:
+  license: XYZ
+```
+- Rerun Installer
+
+## SMTP Configs for Email Notifications
+
+The available fields for SMTP configuration are documented in the [configuration_parameters.md](configuration_parameters.md). Each includes `SMTP` in its name. 
+For example:    
+
+```yaml
+sysdig:
+  smtpServer: smtp.sendgrid.net
+  smtpServerPort: 587
+  #User,Password can be empty if the server does not require authentication
+  smtpUser: apikey
+  smtpPassword: XY.abcdefghijk
+  smtpProtocolTLS: true
+  smtpProtocolSSL: false
+  #Optional Email Header
+  smtpFromAddress: sysdig@mycompany.com
+```
+To configure email settings to be used for a notification channel, copy the parameters and appropriate values into your `values.yaml`               
+
+## Configure AWS Credentials Using the Installer
+
+The available fields for AWS credentials are documented in the [configuration_parameters.md.](configuration_parameters.md#sysdigaccesskey) 
+
+```yaml
+sysdig:      
+  accessKey: my_awesome_aws_access_key
+  secretKey: my_super_secret_secret_key
+```
+
+## Use hostPath for Static Storage of Sysdig Components
+
+As described in the Installation Storage Requirements, the Installer
+assumes usage of a dynamic storage provider (AWS or GKE). In case these are
+not used in your environment, add the entries below to the values.yaml to
+configure static storage.
+
+Based on the `size` entered in the values.yaml file (small/medium/large), the
+Installer assumes a minimum number of replicas and nodes to be provided.
+You will enter the names of the nodes on which you will run the Cassandra,
+ElasticSearch, mySQL and Postgres components of Sysdig in the values.yaml, as
+in the parameters and example below.
+
+### Parameters
+
+`storageClassProvisioner`: hostPath.<br>
+`sysdig.cassandra.hostPathNodes`: The number of nodes configured here needs to
+be at minimum 1 when configured `size` is `small`, 3 when configured `size` is
+`medium` and 6 when configured `size` is large.<br>
+`elasticsearch.hostPathNodes`: The number of nodes configured here needs to be
+be at minimum 1 when configured `size` is `small`, 3 when configured `size` is
+`medium` and 6 when configured `size` is large.<br>
+`sysdig.mysql.hostPathNodes`: When sysdig.mysqlHa is configured to true this has
+to be at least 3 nodes and when sysdig.mysqlHa is not configured it should be
+at least one node.<br>
+`sysdig.postgresql.hostPathNodes`: This can be ignored if Sysdig Secure is not
+licensed or used on this environment. If Secure is used, then the parameter
+should be set to 1, regardless of the environment size setting.<br>
+
+### Example
+
+```yaml
+storageClassProvisioner: hostPath
+elasticsearch:
+  hostPathNodes:
+    - my-cool-host1.com
+    - my-cool-host2.com
+    - my-cool-host3.com
+    - my-cool-host4.com
+    - my-cool-host5.com
+    - my-cool-host6.com
+sysdig:
+  cassandra:
+    hostPathNodes:
+      - my-cool-host1.com
+      - my-cool-host2.com
+      - my-cool-host3.com
+      - my-cool-host4.com
+      - my-cool-host5.com
+      - my-cool-host6.com
+  mysql:
+    hostPathNodes:
+      - my-cool-host1.com
+  postgresql:
+    hostPathNodes:
+      - my-cool-host1.com
+```
+
+## Run Only Sysdig Pods on a Node Using Taints and Tolerations
+
+If you have a large shared Kubernetes cluster and want to dedicate a few nodes for just the Sysdig backend component installation, you can use the Kubernetes concept of [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
+The basic process is:
+
+1. Assign labels and taints to the relevant nodes.
+2. Review the sample [node-labels-and-taints values.yaml](examples/node-labels-and-taints/values.yaml) in the Sysdig github repo.
+3. Copy that section to your own `values.yaml` file and edit with labels and taints you assigned.
+    
+Example from the sample file:
+
+```yaml
+# To make the ‘tolerations’ code sample below functional, assign nodes the taint 
+# dedicated=sysdig:NoSchedule. E.g:
+# kubectl taint my-awesome-node01 dedicated=sysdig:NoSchedule
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: sysdig
+      effect: "NoSchedule"
+# To make the Label code sample below functional, assign nodes the label 
+# role=sysdig. 
+# e.g: kubectl label nodes my-awesome-node01 role=sysdig
+  nodeaffinityLabel:
+    key: role
+    value: sysdig
+```
+
+## Replace a Self-Signed Cert with Custom Cert
+
+Installer automatically generates a self-signed certificate during install. To use a custom certificate you would
+
+- Add your cert and key to the /certs directory ex: (server.crt, server.key)
+​
+- Update values.yaml:
+
+    ```yaml
+    sysdig:  
+      certificate:    
+        crt: certs/server.crt    
+        key: certs/server.key
+    ```
+- Rerun Installer
+
+The [configuration\_parameter.md](configuration_parameters.md#sysdigcertificatecrt) gives full details on `sysdig.certificate.crt` and `sysdig.certificate.key`
+
+## Optional: Custom Self-Signed Certificate
+
+Sysdig Monitor/Cloud/etc uses a self-signed SSL/TLS security certificate, unless a custom certificate is provided.
+
+The example command below creates a custom, unsigned certificate called `MyCert.pem`; the certificate has a private key called `MyCert.key`, and is valid for five years
+​
+```bash
+sudo openssl req -new -x509 -sha256 -days 1825 -nodes -out ./MyCert.pem -keyout ./MyCert.key
+```
+
+# Patching Process
+
+Patching can be used to customize or "tweak" the default behavior of the Installer to accommodate the unique requirements of a specific environment. Use patching to modify the parameters that are not exposed by the`values.yaml`. Refer to the `configuration_parameters.md` for more detail about various parameters.  
+
+The most common use case for patching is during updates. When generating the differences between an existing installation and the upgrade, you may see previously customized configurations that the upgrade would overwrite, but that you want to preserve.
+
+### Patching Process
+
+If you have run ` generate diff ` and found a configuration that you need to tweak (e.g. the installer will delete something you want to keep, or you need to add something that isn't there), then follow these general steps:
+
+-   Create an `overlays `directory in the same location as the `values.yaml`.
+
+> **Note**
+> This directory, and the patch.yaml you create for it, must be kept. The installer will use it during future upgrades of Sysdig.
+
+-   Create a `.yaml` file to be used for patching. You can name it whatever you want; we will call it patch.yaml for this example.
+
+-   Patch files must include, at a minimum:
+
+```text
+    -   `apiVersion`
+
+    -   `kind`
+
+    -   `metadata.name`
+```
+
+Then you add the specific configuration required for your needs. See one example below.
+
+You will need this patch definition for every Kubernetes object you want to patch.
+
+-   Run `generate diff `again and check that the outcome will be what you want.
+
+-   When satisfied, complete the update by changing the scripts value to deploy and running the installer. If you want to add another patch, you can either add a separate `.yaml `file or a new YAML document separated by `---`. 
+
+The recommended practice is to use a single patch per Kubernetes object.
+
+### Example
+
+Presume you have the following generated configuration:
+
+```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app: sysdigcloud
+        role: api
+      name: sysdigcloud-api
+      namespace: sysdigcloud
+    spec:
+      clusterIP: None
+      ports:
+      - name: api
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+      selector:
+        app: sysdigcloud
+        role: api
+      sessionAffinity: None
+      type: ClusterIP
+```
+
+#### To Add to the Generated Configuration
+
+Suppose you want to add an extra label `my-awesome-label: my-awesome-value` to the Service object. Then in the patch.yaml, you would put the following:
+
+```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: sysdigcloud-api
+      labels:
+        my-awesome-label: my-awesome-value
+```
+
+Run the installer again, and the configuration would be as follows:
+
+```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app: sysdigcloud
+        role: api
+        my-awesome-label: my-awesome-value
+      name: sysdigcloud-api
+      namespace: sysdigcloud
+    spec:
+      clusterIP: None
+      ports:
+      - name: api
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+      selector:
+        app: sysdigcloud
+        role: api
+      sessionAffinity: None
+      type: ClusterIP
+```
+
+#### To Remove from the Generated Configuration
+
+Supposed you wanted to remove all the labels. Then in the patch.yaml, you would put the following:
+
+```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: sysdigcloud-api
+      labels:
+```
+
+Run the installer again, and the configuration would be as follows:
+
+```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      name: sysdigcloud-api
+      namespace: sysdigcloud
+    spec:
+      clusterIP: None
+      ports:
+      - name: api
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+      selector:
+        app: sysdigcloud
+        role: api
+      sessionAffinity: None
+      type: ClusterIP
+```

--- a/3.6.2/agent_install.md
+++ b/3.6.2/agent_install.md
@@ -1,0 +1,24 @@
+# Agent Install
+
+The Sysdig agent can be installed along with Sysdig Monitor and/or Sysdig Secure, or by itself. This is determined by the value `apps` in the `values.yaml` file.
+
+If you use the installer to add agent(s), note that not all of the agent configurations are enabled. You may need to do further edits in the agent config files. 
+
+This section assumes you will run the agent container as a Kubernetes pod, which then enables the Sysdig agent automatically to detect and monitor your Kubernetes environment. To set up the agent, you need the api key for agent from the settings menu in Sysdig Monitor/Sysdig Secure. Instructions for retrieving the api key can be found [here](https://docs.sysdig.com/en/agent-installation--overview-and-key.html).
+
+If you are setting up both Monitor and Agent together, you can provide a blank value for the `agent.apiKey`. The agent will be launched with the appropriate api key and the value updated in the `values.yaml` file.
+
+- Copy the current version sysdig-chart/values.yaml to your working directory.
+
+  ```bash
+  wget https://raw.githubusercontent.com/draios/sysdigcloud-kubernetes/installer/installer/values.yaml
+  ```
+
+- The following values are necessary for setting up Sysdig Agent. Edit the values.yaml to contain the following values:
+
+  - [`apps`](configuration_parameters.md#apps): Specifies the Sysdig Platform components to be installed. Make sure `agent` is one of the values here.
+  - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size
+    defines CPU and Memory limits for the Agent Pods. Valid options are: small, medium and
+    large.
+  - [`agent.apiKey`](configuration_parameters.md#agentapikey): Sysdig Agent api key for running agents.
+  - [`agent.collectorEndpoint`](configuration_parameters.md#agentcollectorendpoint): Sysdig Collector Address

--- a/3.6.2/configuration_parameters.md
+++ b/3.6.2/configuration_parameters.md
@@ -1,0 +1,6934 @@
+# Configuration Parameters
+
+## **quaypullsecret**
+**Required**: `true`<br>
+**Description**: quay.io credentials provided with your Sysdig purchase confirmation
+  mail.<br>
+**Options**:<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+quaypullsecret: Y29tZS13b3JrLWF0LXN5c2RpZwo=
+```
+
+## **schema_version**
+**Required**: `true`<br>
+**Description**: Represents the schema version of the values.yaml
+configuration. Versioning follows [Semver](https://semver.org/) (Semantic
+Versioning) and maintains semver guarantees about versioning.<br>
+**Options**:<br>
+**Default**: `1.0.0`<br>
+**Example**:
+
+```yaml
+schema_version: 1.0.0
+```
+
+## **size**
+**Required**: `true`<br>
+**Description**: Specifies the size of the cluster. Size defines CPU, Memory,
+Disk, and Replicas.<br>
+**Options**: `small|medium|large`<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+size: medium
+```
+
+## **storageClassProvisioner**
+**Required**: `false`<br>
+**Description**: The name of the [storage class
+provisioner](https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner)
+to use when creating the configured storageClassName parameter. Use hostPath
+or local in clusters that do not have a provisioner. For setups where
+Persistent Volumes and Persistent Volume Claims are created manually this
+should be configured as `none`. If this is not configured
+[`storageClassName`](#storageclassname) needs to be configured.<br>
+**Options**: `aws|gke|hostPath|none`<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+storageClassProvisioner: aws
+```
+
+## **apps**
+**Required**: `false`<br>
+**Description**: Specifies the Sysdig Platform components to be installed.<br>
+Combine multiple components by space separating them. Specify at least one
+app, for example, `monitor`.<br>
+**Options**: `monitor|monitor secure|agent|monitor agent|monitor secure agent`<br>
+**Default**: `monitor secure`<br>
+**Example**:
+
+```yaml
+apps: monitor secure
+```
+
+## **airgapped_registry_name**
+**Required**: `false`<br>
+**Description**: The URL of the airgapped (internal) docker registry. This URL
+is used for installations where the Kubernetes cluster can not pull images
+directly from Quay. See [airgap instructions
+multi-homed](usage.md#airgap-installation-with-installation-machine-multi-homed)
+and [full airgap instructions](../usage.md#full-airgap-installation) for more
+details.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+airgapped_registry_name: my-awesome-domain.docker.io
+```
+
+## **airgapped_repository_prefix**
+**Required**: `false`<br>
+**Description**: This defines custom repository prefix for airgapped_registry.
+Tags and pushes images as airgapped_registry_name/airgapped_repository_prefix/image_name:tag<br>
+**Options**:<br>
+**Default**: sysdig<br>
+**Example**:
+
+```yaml
+#tags and pushes the image to <airgapped_registry_name>/foo/bar/<image_name:tag>
+airgapped_repository_prefix: foo/bar
+```
+
+## **airgapped_registry_password**
+**Required**: `false`
+**Description**: The password for the configured
+`airgapped_registry_username`. Ignore this parameter if the registry does not
+require authentication.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+airgapped_registry_password: my-@w350m3-p@55w0rd
+```
+
+## **airgapped_registry_username**
+**Required**: `false`<br>
+**Description**: The username for the configured `airgapped_registry_name`.
+Ignore this parameter if the registry does not require authentication.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+airgapped_registry_username: bob+alice
+```
+
+## **deployment**
+**Required**: `false`<br>
+**Description**: The name of the Kubernetes installation.<br>
+**Options**: `iks|kubernetes|openshift`<br>
+**Default**: `kubernetes`<br>
+**Example**:
+
+```yaml
+deployment: kubernetes
+```
+
+## **context**
+**Required**: `false`<br>
+**Description**: Kubernetes context to use for deploying Sysdig Platform.
+If this param is not not or a blank value is specified, it will use the default context.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+context: production
+```
+
+## **namespace**
+**Required**: `false`<br>
+**Description**: Kubernetes namespace to deploy Sysdig Platform to.<br>
+**Options**:<br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+namespace: sysdig
+```
+
+## **scripts**
+**Required**: `false`<br>
+**Description**: Defines which scripts needs to be run.<br>
+  `generate`: performs templating and customization.<br>
+  `diff`: generates diff against in-cluster configuration.<br>
+  `deploy`: applies the generated script in Kubernetes environment.<br>
+These options can be combined by space separating them.<br>
+**Options**: `generate|diff|deploy|generate diff|generate deploy|diff deploy|generate diff deploy`<br>
+**Default**: `generate deploy`<br>
+**Example**:
+
+```yaml
+scripts: generate diff
+```
+
+## **storageClassName**
+**Required**: `false`<br>
+**Description**: The name of the preconfigured [storage
+class](https://kubernetes.io/docs/concepts/storage/storage-classes/). If the
+storage class does not exist, Installer will attempt to create it using the
+`storageClassProvisioner` as the provisioner. This has no effect if
+`storageClassProvisioner` is configured to `none`.<br>
+**Options**:<br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+storageClassName: sysdig
+```
+
+## ~~**cloudProvider.create_loadbalancer**~~ (**Deprecated**)
+**Required**: `false`<br>
+**Description**: This is deprecated, prefer
+[`sysdig.ingressNetworking`](#sysdigingressnetworking) instead. When set to
+true a service of type
+[LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/#loadbalancer)
+is created.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+cloudProvider:
+  create_loadbalancer: true
+```
+
+## **cloudProvider.name**
+**Required**: `false`<br>
+**Description**: The name of the cloud provider Sysdig Platform will run on.<br>
+**Options**: `aws|gke`<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+cloudProvider:
+  name: aws
+```
+
+## **cloudProvider.isMultiAZ**
+**Required**: `false`<br>
+**Description**: Specifies whether the underlying Kubernetes cluster is
+deployed in multiple availability zones. The parameter requires
+[`cloudProvider.name`](#cloudprovidername) to be configured. <br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+cloudProvider:
+  isMultiAZ: false
+```
+
+## **cloudProvider.region**
+**Required**: `false`<br>
+**Description**: The cloud provider region the underlying Kubernetes Cluster
+runs on. This parameter is required if
+[`cloudProvider.name`](#cloudprovidername) is configured.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+cloudProvider:
+  region: us-east-1
+```
+
+## **elasticsearch.hostPathNodes**
+**Required**: `false`<br>
+**Description**: An array of node hostnames printed out by the `kubectl get
+node -o name` command. ElasticSearch hostPath persistent volumes should be
+created on these nodes. The number of nodes must be at minimum whatever the
+value of
+[`sysdig.elasticsearchReplicaCount`](#sysdigelasticsearchreplicacount) is.
+This is required if configured
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: [] <br>
+
+**Example**:
+
+```yaml
+elasticsearch:
+  hostPathNodes:
+    - my-cool-host1.com
+    - my-cool-host2.com
+    - my-cool-host3.com
+    - my-cool-host4.com
+    - my-cool-host5.com
+    - my-cool-host6.com
+```
+
+
+## **elasticsearch.jvmOptions**
+**Required**: `false`<br>
+**Description**: Custom configuration for Elasticsearch JVM.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+elasticsearch:
+  jvmOptions: -Xms4G -Xmx4G
+```
+
+## **elasticsearch.external**
+**Required**: `false`<br>
+**Description**: If set does not create a local Elasticsearch cluster, tries connecting to an external Elasticsearch cluster.
+This can be used in conjunction with [`elasticsearch.hostname`](#elasticsearchhostname) <br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  external: true
+```
+
+## **elasticsearch.hostname**
+**Required**: `false`<br>
+**Description**:  External Elasticsearch hostname can be provided here and certificates for clients can be provided under certs/elasticsearch-tls-certs.<br>
+**Options**: <br>
+**Default**: 'sysdigcloud-elasticsearch'<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  external: true
+  hostname: external.elasticsearch.cluster
+```
+
+## **elasticsearch.useES6**
+**Required**: `false`<br>
+**Description**: Install Elasticsearch 6.8.x along with user authentication and TLS-encrypted data-in-transit
+using Elasticsearch's native TLS Encrpytion.
+If TLS Encrpytion is enabled Installer does the following in the provided order:
+  1. Checks for existing Elasticsearch certificates in the provided environment to setup ES cluster. (applicable for upgrades)
+  2. If they are not present Installer autogenerates tls certificates and uses them to setup es cluster.
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  useES6: true
+```
+
+## **elasticsearch.tlsencryption.adminUser**
+**Required**: `false`<br>
+**Description**: The user bound to the ElasticSearch admin role.<br>
+**Options**: <br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  tlsencryption:
+    adminUser: admin
+```
+
+## ~~**elasticsearch.searchguard.enabled**~~ (**Deprecated**)
+**Required**: `false`<br>
+**Description**: Enables user authentication and TLS-encrypted data-in-transit
+with [Searchguard](https://search-guard.com/)
+If Searchguard is enabled Installer does the following in the provided order:
+  1. Checks for user provided certificates under certs/elasticsearch-tls-certs if present uses that to setup elasticsearch(es) cluster.
+  2. Checks for existing searchguard certificates in the provided environment to setup ES cluster. (applicable for upgrades)
+  3. If neither of them are present Installer autogenerates searchguard certificates and uses them to setup es cluster.
+
+
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  searchguard:
+    enabled: false
+```
+
+## ~~**elasticsearch.searchguard.adminUser**~~ (**Deprecated**)
+**Required**: `false`<br>
+**Description**: The user bound to the ElasticSearch Searchguard admin role.<br>
+**Options**: <br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  searchguard:
+    adminUser: admin
+```
+
+## **elasticsearch.snitch.extractCMD**
+**Required**: `false`<br>
+**Description**: The command used to determine [elasticsearch cluster routing
+allocation awareness
+attributes](https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html).
+The command will be passed to the bash eval command and is expected to return
+a single string. For example: `cut -d- -f2 /host/etc/hostname`.<br>
+**Options**: <br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  snitch:
+    extractCMD: cut -d- -f2 /host/etc/hostname
+```
+
+## **elasticsearch.snitch.hostnameFile**
+**Required**: `false`<br>
+**Description**: The name of the location to bind mount the host's
+`/etc/hostname` file to. This can be combined with
+[`elasticsearch.snitch.extractCMD`](#elasticsearchsnitchextractcmd) to
+determine cluster routing allocation associated with the node's hostname.<br>
+**Options**: <br>
+**Default**: `sysdig`<br>
+**Example**:
+
+```yaml
+elasticsearch:
+  snitch:
+    hostnameFile: /host/etc/hostname
+```
+
+## **hostPathCustomPaths.cassandra**
+**Required**: `false`<br>
+**Description**: The directory to bind mount Cassandra pod's
+`/var/lib/cassandra` to on the host. This parameter is relevant only when
+`storageClassProvisioner` is `hostPath`. <br>
+**Options**: <br>
+**Default**: `/var/lib/cassandra`<br>
+**Example**:
+
+```yaml
+hostPathCustomPaths:
+  cassandra: `/sysdig/cassandra`
+```
+
+## **hostPathCustomPaths.elasticsearch**
+**Required**: `false`<br>
+**Description**: The directory to bind mount elasticsearch pod's
+`/usr/share/elasticsearch` to on the host. This parameter is relevant only when
+`storageClassProvisioner` is `hostPath`.<br>
+**Options**: <br>
+**Default**: `/usr/share/elasticsearch`<br>
+**Example**:
+
+```yaml
+hostPathCustomPaths:
+  elasticsearch: `/sysdig/elasticsearch`
+```
+
+## **hostPathCustomPaths.mysql**
+**Required**: `false`<br>
+**Description**: The directory to bind mount mysql pod's `/var/lib/mysql` to
+on the host. This is relevant only when `storageClassProvisioner` is
+`hostPath`.<br>
+**Options**:<br>
+**Default**: `/var/lib/mysql`<br>
+**Example**:
+
+```yaml
+hostPathCustomPaths:
+  mysql: `/sysdig/mysql`
+```
+
+## **hostPathCustomPaths.postgresql**
+**Required**: `false`<br>
+**Description**: The directory to bind mount PostgreSQL pod's
+`/var/lib/postgresql/data/pgdata` to on the host. This parameter is relevant
+only when `storageClassProvisioner` is `hostPath`.<br>
+**Options**: <br>
+**Default**: `/var/lib/postgresql/data/pgdata`<br>
+**Example**:
+
+```yaml
+hostPathCustomPaths:
+  postgresql: `/sysdig/pgdata`
+```
+
+## **nodeaffinityLabel.key**
+**Required**: `false`<br>
+**Description**: The key of the label that is used to configure the nodes that the
+Sysdig Platform pods are expected to run on. The nodes are expected to have
+been labeled with the key.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+nodeaffinityLabel:
+  key: instancegroup
+```
+
+## **nodeaffinityLabel.value**
+**Required**: `false`<br>
+**Description**: The value of the label that is used to configure the nodes
+that the Sysdig Platform pods are expected to run on. The nodes are expected
+to have been labeled with the value of
+[`nodeaffinityLabel.key`](#nodeaffinitylabelkey), and is required if
+[`nodeaffinityLabel.key`](#nodeaffinitylabelkey) is configured.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+nodeaffinityLabel:
+  value: sysdig
+```
+
+## **pvStorageSize.large.cassandra**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Cassandra in a
+cluster of [`size`](#size) large. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 300Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  large:
+    cassandra: 500Gi
+```
+
+## **pvStorageSize.large.elasticsearch**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Elasticsearch
+in a cluster of [`size`](#size) large. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 300Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  large:
+    elasticsearch: 500Gi
+```
+
+## **pvStorageSize.large.mysql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to MySQL in a
+cluster of [`size`](#size) large. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 25Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  large:
+    mysql: 100Gi
+```
+
+## **pvStorageSize.large.postgresql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to PostgreSQL in a
+cluster of [`size`](#size) large. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 60Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  large:
+    postgresql: 100Gi
+```
+
+## **pvStorageSize.medium.cassandra**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Cassandra in a
+cluster of [`size`](#size) medium. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 100Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  medium:
+    cassandra: 300Gi
+```
+
+## **pvStorageSize.medium.elasticsearch**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Elasticsearch in a
+cluster of [`size`](#size) medium. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 100Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  medium:
+    elasticsearch: 300Gi
+```
+
+## **pvStorageSize.medium.mysql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to MySQL in a
+cluster of [`size`](#size) medium. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 25Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  medium:
+    mysql: 100Gi
+```
+
+## **pvStorageSize.medium.postgresql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to PostgreSQL in a
+cluster of [`size`](#size) medium. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 60Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  medium:
+    postgresql: 100Gi
+```
+
+## **pvStorageSize.small.cassandra**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Cassandra in a
+cluster of [`size`](#size) small. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 30Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  small:
+    cassandra: 100Gi
+```
+
+## **pvStorageSize.small.elasticsearch**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to Elasticsearch
+in a cluster of [`size`](#size) small. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 30Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  small:
+    elasticsearch: 100Gi
+```
+
+## **pvStorageSize.small.mysql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to MySQL in a
+cluster of [`size`](#size) small. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 25Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  small:
+    mysql: 100Gi
+```
+
+## **pvStorageSize.small.postgresql**
+**Required**: `false`<br>
+**Description**: The size of the persistent volume assigned to PostgreSQL in a
+cluster of [`size`](#size) small. This option is ignored if
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: 30Gi<br>
+**Example**:
+
+```yaml
+pvStorageSize:
+  small:
+    postgresql: 100Gi
+```
+
+## **sysdig.activityAuditVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of Activity Audit services.<br>
+**Options**:<br>
+**Default**: [`sysdig.monitorVersion`](#sysdigmonitorversion)<br>
+**Example**:
+
+```yaml
+sysdig:
+  activityAuditVersion: 3.6.2.7998
+```
+
+## **sysdig.profilingVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of Profiling services.<br>
+**Options**:<br>
+**Default**: [`sysdig.monitorVersion`](#sysdigmonitorversion)<br>
+**Example**:
+
+```yaml
+sysdig:
+  profilingVersion: 3.6.2.7998
+```
+
+## **sysdig.anchoreVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of the Sysdig Anchore Core.<br>
+**Options**:<br>
+**Default**: 0.6.1.2<br>
+**Example**:
+
+```yaml
+sysdig:
+  anchoreVersion: 0.8.1.2
+```
+
+## **sysdig.accessKey**
+**Required**: `false`<br>
+**Description**: The AWS (or AWS compatible) accessKey to be used by Sysdig
+components to communicate with AWS (or an AWS compatible API).<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  accessKey: my_awesome_aws_access_key
+```
+
+## **sysdig.secretKey**
+**Required**: `false`<br>
+**Description**: The AWS (or AWS compatible) secretKey to be used by Sysdig
+components to communicate with AWS (or an AWS compatible API).<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  secretKey: my_super_secret_secret_key
+```
+
+## **sysdig.s3.enabled**
+**Required**: `false`<br>
+**Description**: Specifies if storing Sysdig Captures in S3 or S3-compatible storage is enabled.<br>
+**Options**:`true|false`<br>
+**Default**:false<br>
+**Example**:
+
+```yaml
+sysdig:
+  s3:
+    enabled: true
+```
+
+## **sysdig.s3.endpoint**
+**Required**: `false`<br>
+**Description**: S3-compatible endpoint for the bucket, this option is ignored if
+[`sysdig.s3.enabled`](#sysdigs3enabled) is not configured. This option is not required if using an AWS S3 Bucket for captures.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  s3:
+    endpoint: s3.us-south.cloud-object-storage.appdomain.cloud
+```
+
+## **sysdig.s3.bucketName**
+**Required**: `false`<br>
+**Description**: Name of the S3 bucket to be used for captures, this option is ignored if
+[`sysdig.s3.enabled`](#sysdigs3enabled) is not configured.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  s3:
+    bucketName: my_awesome_bucket
+```
+
+## **sysdig.cassandraVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of Cassandra.<br>
+**Options**:<br>
+**Default**: 2.1.21.13<br>
+**Example**:
+
+```yaml
+sysdig:
+  cassandraVersion: 2.1.21.16
+```
+
+## **sysdig.cassandra.external**
+**Required**: `false`<br>
+**Description**: If set does not create a local Cassandra cluster, tries connecting to an external Cassandra cluster.
+This can be used in conjunction with [`sysdig.cassandra.endpoint`](#sysdigcassandraendpoint) <br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+  external: true
+```
+
+## **sysdig.cassandra.endpoint**
+**Required**: `false`<br>
+**Description**:  External Cassandra endpoint can be provided here. <br>
+**Options**: <br>
+**Default**: 'sysdigcloud-cassandra'<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+  external: true
+  endpoint: external.cassandra.cluster
+```
+
+## **sysdig.cassandra.secure**
+**Required**: `false`<br>
+**Description**: Enables cassandra server and clients to use authentication. <br>
+**Options**: `true|false`<br>
+**Default**:`false`<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+   secure: true
+   ssl: true
+```
+
+## **sysdig.cassandra.ssl**
+**Required**: `false`<br>
+**Description**: Enables cassandra server and clients communicate over ssl. <br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+   secure: true
+   ssl: true
+```
+
+## **sysdig.cassandra.user**
+**Required**: `false`<br>
+**Description**: Sets cassandra user. The only gotcha is the user cannot be a substring of sysdigcloud-cassandra.<br>
+**Options**: <br>
+**Default**: `sysdigcassandra`<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+   user: cassandrauser
+```
+
+## **sysdig.cassandra.password**
+**Required**: `false`<br>
+**Description**: Sets cassandra password <br>
+**Options**: <br>
+**Default**: Autogenerated 16 alphanumeric characters<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+   user: cassandrauser
+   password: cassandrapassword
+```
+
+## **sysdig.cassandra.workloadName**
+**Required**: `false`<br>
+**Description**: Name assigned to the Cassandra objects(statefulset and
+service)<br>
+**Options**: <br>
+**Default**: `sysdigcloud-cassandra`<br>
+**Example**:
+
+```yaml
+sysdig:
+ cassandra:
+   workloadName: sysdigcloud-cassandra
+```
+
+## **sysdig.cassandra.customOverrides**
+**Required**: `false`<br>
+**Description**: The custom overrides of Cassandra's default configuration. The parameter
+expects a YAML block of key-value pairs as described in the [Cassandra
+documentation](https://docs.datastax.com/en/archived/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html).<br>
+**Options**:<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+sysdig:
+  cassandra:
+    customOverrides: |
+      hinted_handoff_enabled: false
+      concurrent_compactors: 8
+      read_request_timeout_in_ms: 10000
+      write_request_timeout_in_ms: 10000
+```
+
+## **sysdig.cassandra.datacenterName**
+**Required**: `false`<br>
+**Description**: The datacenter name used for the [Cassandra
+Snitch](http://cassandra.apache.org/doc/latest/operating/snitch.html).<br>
+**Options**:<br>
+**Default**:  In AWS the value is ec2Region as determined by the code
+[here](https://github.com/apache/cassandra/blob/a85afbc7a83709da8d96d92fc4154675794ca7fb/src/java/org/apache/cassandra/locator/Ec2Snitch.java#L61-L63),
+elsewhere defaults to an empty string. <br>
+**Example**:
+
+```yaml
+sysdig:
+  cassandra:
+    datacenterName: my-cool-datacenter
+```
+
+## **sysdig.cassandra.jvmOptions**
+**Required**: `false`<br>
+**Description**: The custom configuration for Cassandra JVM.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  cassandra:
+    jvmOptions: -Xms6G -Xmx6G -XX:+PrintGCDateStamps -XX:+PrintGCDetails
+```
+
+## **sysdig.cassandra.hostPathNodes**
+**Required**: `false`<br>
+**Description**: An array of node hostnames printed out by the `kubectl get node -o
+name` command. These are the nodes where Cassandra hostPath persistent volumes should be created on. The number of nodes must be at minimum whatever the value of
+[`sysdig.cassandraReplicaCount`](#sysdigcassandrareplicacount) is. This is
+required if configured [`storageClassProvisioner`](#storageclassprovisioner)
+is `hostPath`.<br>
+**Options**:<br>
+**Default**: [] <br>
+
+**Example**:
+
+```yaml
+sysdig:
+  cassandra:
+    hostPathNodes:
+      - my-cool-host1.com
+      - my-cool-host2.com
+      - my-cool-host3.com
+      - my-cool-host4.com
+      - my-cool-host5.com
+      - my-cool-host6.com
+```
+
+## **sysdig.collectorPort**
+**Required**: `false`<br>
+**Description**: The port to publicly serve Sysdig collector on.<br>
+_**Note**: collectorPort is not configurable in openshift deployments. It is always 443._<br>
+**Options**: `1024-65535`<br>
+**Default**: `6443` <br>
+**Example**:
+
+```yaml
+sysdig:
+  collectorPort: 7000
+```
+
+## **sysdig.certificate.customCA**
+**Required**: `false`<br>
+**Description**:
+The Sysdig platform may sometimes open connections over SSL to certain external services, including:
+ - LDAP over SSL
+ - SAML over SSL
+ - OpenID Connect over SSL
+ - HTTPS Proxies<br>
+If the signing authorities for the certificates presented by these services are not well-known to the Sysdig Platform (e.g., if you maintain your own Certificate Authority), they are not trusted by default.
+
+To allow the Sysdig platform to trust these certificates, use this configuration to upload one or more PEM-format CA certificates. You must ensure you've uploaded all certificates in the CA approval chain to the root CA.
+
+This configuration when set expects certificates with .crt extension under certs/custom-java-certs/ in the same level as `values.yaml`<br>
+**Options**: `true|false`<br>
+**Default**: false<br>
+**Example**:
+
+```bash
+#In the example directory structure below, certificate1.crt and certificate2.crt will be added to the trusted list.
+bash-5.0$ find certs values.yaml
+certs
+certs/custom-java-certs
+certs/custom-java-certs/certificate1.crt
+certs/custom-java-certs/certificate2.crt
+values.yaml
+```
+
+```yaml
+sysdig:
+  certificate:
+    customCA: true
+```
+
+## **sysdig.dnsName**
+**Required**: `true`<br>
+**Description**: The domain name the Sysdig APIs will be served on.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  dnsName: my-awesome-domain-name.com
+```
+
+## **sysdig.elasticsearchVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of Elasticsearch.<br>
+**Options**:<br>
+**Default**: 5.6.16.18<br>
+**Example**:
+
+```yaml
+sysdig:
+  elasticsearchVersion: 5.6.16.18
+```
+
+## **sysdig.haproxyVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of HAProxy ingress controller. The
+parameter is relevant only when configured `deployment` is `kubernetes`.<br>
+**Options**:<br>
+**Default**: v0.7-beta.7.1<br>
+**Example**:
+
+```yaml
+sysdig:
+  haproxyVersion: v0.7-beta.7.1
+```
+
+## **sysdig.ingressNetworking**
+**Required**: `false`<br>
+**Description**: The networking construct used to expose the Sysdig API and collector.
+* hostnetwork, sets the hostnetworking in ingress daemonset and opens host ports for api and collector. This does not create a service.
+* loadbalancer, creates a service of type [`loadbalancer`](https://kubernetes.io/docs/concepts/services-networking/#loadbalancer)
+* nodeport, creates a service of type [`nodeport`](https://kubernetes.io/docs/concepts/services-networking/#nodeport). The node ports can be customized with:
+  * [`sysdig.ingressNetworkingInsecureApiNodePort`](#sysdigingressnetworkinginsecureapinodeport)
+  * [`sysdig.ingressNetworkingApiNodePort`](#sysdigingressnetworkingapinodeport)
+  * [`sysdig.ingressNetworkingCollectorNodePort`](#sysdigingressnetworkingcollectornodeport)
+* external, assumes external ingress is used and does not create ingress objects.
+
+**Options**:
+[`hostnetwork`](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces)|[`loadbalancer`](https://kubernetes.io/docs/concepts/services-networking/#loadbalancer)|[`nodeport`](https://kubernetes.io/docs/concepts/services-networking/#nodeport)| external
+
+**Default**: `hostnetwork`
+**Example**:
+
+```yaml
+sysdig:
+  ingressNetworking: loadbalancer
+```
+
+## **sysdig.ingressNetworkingInsecureApiNodePort**
+**Required**: `false`<br>
+**Description**: When [`sysdig.ingressNetworking`](#sysdigingressnetworking)
+is configured as `nodeport`, this is the NodePort requested by Installer
+from Kubernetes for the Sysdig non-TLS API endpoint.<br>
+**Options**: <br>
+**Default**: `30000`
+**Example**:
+
+```yaml
+sysdig:
+  ingressNetworkingInsecureApiNodePort: 30000
+```
+
+## **sysdig.ingressLoadBalancerAnnotation**
+**Required**: `false`<br>
+**Description**: Annotations that will be added to the
+`haproxy-ingress-service` object, this is useful to set annotations related to
+creating internal loadbalancers.<br>
+**Options**: <br>
+**Example**:
+
+```yaml
+sysdig:
+  ingressLoadBalancerAnnotation:
+    cloud.google.com/load-balancer-type: Internal
+```
+
+## **sysdig.ingressNetworkingApiNodePort**
+**Required**: `false`<br>
+**Description**: When [`sysdig.ingressNetworking`](#sysdigingressnetworking)
+is configured as `nodeport`, this is the NodePort requested by Installer
+from Kubernetes for the Sysdig TLS API endpoint.<br>
+**Options**: <br>
+**Default**: `30001`
+**Example**:
+
+```yaml
+sysdig:
+  ingressNetworkingApiNodePort: 30001
+```
+
+## **sysdig.ingressNetworkingCollectorNodePort**
+**Required**: `false`<br>
+**Description**: When [`sysdig.ingressNetworking`](#sysdigingressnetworking)
+is configured as `nodeport`, this is the NodePort requested by Installer
+from Kubernetes for the Sysdig collector endpoint.<br>
+**Options**: <br>
+**Default**: `30002`
+**Example**:
+
+```yaml
+sysdig:
+  ingressNetworkingCollectorNodePort: 30002
+```
+
+## **sysdig.license**
+**Required**: `true`<br>
+**Description**: Sysdig license provided with the deployment.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  license: replace_with_your_license
+```
+
+## **sysdig.monitorVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of the Sysdig Monitor. **Do not modify
+this unless you know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:<br>
+**Default**: 3.6.2.7998<br>
+**Example**:
+
+```yaml
+sysdig:
+  monitorVersion: 3.6.2.7998
+```
+
+## **sysdig.scanningVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of the Sysdig Scanning components, if
+this is not configured it defaults to `sysdig.monitorVersion` **Do not modify
+this unless you know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:<br>
+**Default**: 3.6.2.7998<br>
+**Example**:
+
+```yaml
+sysdig:
+  scanningVersion: 3.6.2.7998
+```
+
+## **sysdig.sysdigAPIVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of Sysdig API components, if
+this is not configured it defaults to `sysdig.monitorVersion` **Do not modify
+this unless you know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:<br>
+**Default**: 3.6.2.7998<br>
+**Example**:
+
+```yaml
+sysdig:
+  sysdigAPIVersion: 3.6.2.7998
+```
+
+## **sysdig.sysdigCollectorVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of Sysdig Collector components, if
+this is not configured it defaults to `sysdig.monitorVersion` **Do not modify
+this unless you know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:<br>
+**Default**: 3.6.2.7998<br>
+**Example**:
+
+```yaml
+sysdig:
+  sysdigCollectorVersion: 3.6.2.7998
+```
+
+## **sysdig.sysdigWorkerVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of Sysdig Worker components, if
+this is not configured it defaults to `sysdig.monitorVersion` **Do not modify
+this unless you know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:<br>
+**Default**: 3.6.2.7998<br>
+**Example**:
+
+```yaml
+sysdig:
+  sysdigWorkerVersion: 3.6.2.7998
+```
+
+## **sysdig.enableAlerter**
+**Required**: `false`<br>
+**Description**: This creates a separate deployment for Alerters while
+disabling this functionality in workers. **Do not modify this unless you
+know what you are doing as modifying it could have unintended
+consequences**<br>
+**Options**:`true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  enableAlerter: true
+```
+
+## **sysdig.mysqlHa**
+**Required**: `false`<br>
+**Description**: Determines if mysql should run in HA mode.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysqlHa: false
+```
+
+## **sysdig.useMySQL8**
+**Required**: `false`<br>
+**Description**: Determines if standalone mysql should run MySQL8.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  useMySQL8: true
+```
+
+## **sysdig.mysqlHaVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of MySQL used for HA.<br>
+**Options**:<br>
+**Default**: 8.0.16.4<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysqlHaVersion: 8.0.16.4
+```
+
+## **sysdig.mysqlHaAgentVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of MySQL Agent used for HA.<br>
+**Options**:<br>
+**Default**: 0.1.1.6<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysqlHaAgentVersion: 0.1.1.6
+```
+
+## **sysdig.mysqlVersion**
+**Required**: `false`<br>
+**Description**: The docker image tag of MySQL.<br>
+**Options**:<br>
+**Default**: 5.6.44.0<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysqlVersion: 5.6.44.0
+```
+
+## **sysdig.mysql8Version**
+**Required**: `false`<br>
+**Description**: The docker image tag of MySQL8.<br>
+**Options**:<br>
+**Default**: 8.0.16.0<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysqlVersion: 8.0.16.0
+```
+
+## **sysdig.mysql.external**
+**Required**: `false`<br>
+**Description**: If set, the installer does not create a local mysql cluster
+instead it sets up the sysdig platform to connect to the configured
+[`sysdig.mysql.hostname`](#sysdigmysqlhostname) <br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    external: true
+```
+
+## **sysdig.mysql.hostname**
+**Required**: `false`<br>
+**Description**: Name of the mySQL host that the sysdig platform components
+should connect to.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    hostname: mysql.foo.com
+```
+
+## **sysdig.mysql.hostPathNodes**
+**Required**: `false`<br>
+**Description**: An array of node hostnames printed out by the `kubectl get
+node -o name` command. These are the nodes where MySQL hostPath persistent
+volumes should be created on. The number of nodes must be at minimum whatever
+the value of [`sysdig.mysqlReplicaCount`](#sysdigmysqlreplicacount) is. This
+parameter is required if configured
+[`storageClassProvisioner`](#storageclassprovisioner) is `hostPath`.<br>
+**Options**:<br>
+**Default**: [] <br>
+
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    hostPathNodes:
+      - my-cool-host1.com
+```
+
+## **sysdig.mysql.maxConnections**
+**Required**: `false`<br>
+**Description**: The maximum permitted number of simultaneous client connections.<br>
+**Options**:<br>
+**Default**: `1024`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    maxConnections: 1024
+```
+
+## **sysdig.mysql.password**
+**Required**: `false`<br>
+**Description**: The password of the MySQL user that the Sysdig Platform backend
+components will use in communicating with MySQL.<br>
+**Options**:<br>
+**Default**: `mysql-admin`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    user: awesome-user
+```
+
+## **sysdig.mysql.user**
+**Required**: `false`<br>
+**Description**: The username of the MySQL user that the Sysdig Platform backend
+components will use in communicating with MySQL.<br>
+_**Note**: Do NOT use `root` user for this value._<br>
+**Options**:<br>
+**Default**: `mysql-admin`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  mysql:
+    user: awesome-user
+```
+
+## **sysdig.natsExporterVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of the Prometheus exporter for NATS.<br>
+**Options**:<br>
+**Default**: 0.6.0.1<br>
+**Example**:
+
+```yaml
+sysdig:
+  natsExporterVersion: 0.6.0.1
+```
+
+## **sysdig.natsStreamingVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of NATS streaming.<br>
+**Options**:<br>
+**Default**: 0.16.2.1<br>
+**Example**:
+
+```yaml
+sysdig:
+  natsStreamingVersion: 0.16.2.1
+```
+
+## **sysdig.nats.secure.enabled**
+**Required**: `false`<br>
+**Description**: NATS Streaming TLS enabled.<br>
+**Options**:<br>
+**Default**: true<br>
+**Example**:
+
+```yaml
+sysdig:
+  nats:
+    secure:
+      enabled: true
+```
+
+## **sysdig.nats.ha.enabled**
+**Required**: `false`<br>
+**Description**: NATS Streaming HA (High Availability) enabled.<br>
+**Options**:<br>
+**Default**: false<br>
+**Example**:
+
+```yaml
+sysdig:
+  nats:
+    ha:
+      enabled: false
+```
+
+## **sysdig.nats.urlha**
+**Required**: `false`<br>
+**Description**: NATS Streaming URL for HA deployment.<br>
+**Options**:<br>
+**Default**: nats://sysdigcloud-nats-streaming-cluster-0.sysdigcloud-nats-streaming-cluster:4222,nats://sysdigcloud-nats-streaming-cluster-1.sysdigcloud-nats-streaming-cluster:4222,nats://sysdigcloud-nats-streaming-cluster-2.sysdigcloud-nats-streaming-cluster:4222<br>
+**Example**:
+
+```yaml
+sysdig:
+  nats:
+    urlha: nats://sysdigcloud-nats-streaming-cluster-0.sysdigcloud-nats-streaming-cluster:4222,nats://sysdigcloud-nats-streaming-cluster-1.sysdigcloud-nats-streaming-cluster:4222,nats://sysdigcloud-nats-streaming-cluster-2.sysdigcloud-nats-streaming-cluster:4222
+```
+
+## **sysdig.nats.urltls**
+**Required**: `false`<br>
+**Description**: NATS Streaming URL for TLS enabled.<br>
+**Options**:<br>
+**Default**: nats://sysdigcloud-nats-streaming-tls:4222<br>
+**Example**:
+
+```yaml
+sysdig:
+  nats:
+    urltls: nats://sysdigcloud-nats-streaming-tls:4222
+```
+
+## **sysdig.openshiftUrl**
+**Required**: `false`<br>
+**Description**: Openshift API url along with its port number, this is
+required if configured `deployment` is `openshift`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  openshiftUrl: https://api.my-awesome-openshift.com:6443
+```
+
+## **sysdig.openshiftUser**
+**Required**: `false`<br>
+**Description**: Username of the user to access the configured
+`sysdig.openshiftUrl`, required if configured `deployment` is `openshift`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  openshiftUser: bob+alice
+```
+
+## **sysdig.openshiftPassword**
+**Required**: `false`<br>
+**Description**: Password of the user(`sysdig.openshiftUser`) to access the
+configured `sysdig.openshiftUrl`, required if configured `deployment` is
+`openshift`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  openshiftPassword: my-@w350m3-p@55w0rd
+```
+
+## **sysdig.postgresVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of Postgres, relevant when configured `apps`
+is `monitor secure`.<br>
+**Options**:<br>
+**Default**: 10.6.11<br>
+**Example**:
+
+```yaml
+sysdig:
+  postgresVersion: 10.6.11
+```
+
+## **sysdig.postgresql.hostPathNodes**
+**Required**: `false`<br>
+**Description**: An array of node hostnames has shown in `kubectl get node -o
+name` that postgresql hostPath persistent volumes should be created on. The
+number of nodes must be at minimum whatever the value of
+[`sysdig.postgresReplicaCount`](#sysdigpostgresreplicacount) is. This is
+required if configured [`storageClassProvisioner`](#storageclassprovisioner)
+is `hostPath`.<br>
+**Options**:<br>
+**Default**: [] <br>
+
+**Example**:
+
+```yaml
+sysdig:
+  postgresql:
+    hostPathNodes:
+      - my-cool-host1.com
+```
+
+## **sysdig.proxy.defaultNoProxy**
+**Required**: `false`<br>
+**Description**: Default comma separated list of addresses or domain names
+that can be reached without going through the configured web proxy. This is
+only relevant if [`sysdig.proxy.enable`](#sysdigproxyenable) is configured and
+should only be used if there is an intent to override the defaults provided by
+Installer otherwise consider [`sysdig.proxy.noProxy`](#sysdigproxynoproxy)
+instead.<br>
+**Options**:<br>
+**Default**: `127.0.0.1, localhost, sysdigcloud-anchore-core`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    defaultNoProxy: 127.0.0.1, localhost, sysdigcloud-anchore-core
+```
+
+## **sysdig.proxy.enable**
+**Required**: `false`<br>
+**Description**: Determines if a [web
+proxy](https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers) should be
+used by Anchore for fetching CVE feed from
+[https://api.sysdigcloud.com/api/scanning-feeds/v1/feeds](https://api.sysdigcloud.com/api/scanning-feeds/v1/feeds) and by the events forwarder to forward to HTTP based targets.<br>
+**Options**:<br>
+**Default**: `false`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+```
+
+## **sysdig.proxy.host**
+**Required**: `false`<br>
+**Description**: The address of the web proxy, this could be a domain name or
+an IP address. This is required if [`sysdig.proxy.enable`](#sysdigproxyenable)
+is configured.<br>
+**Options**:<br>
+**Default**:<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    host: my-awesome-proxy.my-awesome-domain.com
+```
+
+## **sysdig.proxy.noProxy**
+**Required**: `false`<br>
+**Description**: Comma separated list of addresses or domain names
+that can be reached without going through the configured web proxy. This is
+only relevant if [`sysdig.proxy.enable`](#sysdigproxyenable) is configured and
+appended to the list in
+[`sysdig.proxy.defaultNoProxy`](#sysdigproxydefaultnoproxy].<br>
+**Options**:<br>
+**Default**: `127.0.0.1, localhost, sysdigcloud-anchore-core`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    noProxy: my-awesome.domain.com, 192.168.0.0/16
+```
+
+## **sysdig.proxy.password**
+**Required**: `false`<br>
+**Description**: The password used to access the configured
+[`sysdig.proxy.host`](#sysdigproxyhost).<br>
+**Options**:<br>
+**Default**:<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    password: F00B@r!
+```
+
+## **sysdig.proxy.port**
+**Required**: `false`<br>
+**Description**: The port the configured
+[`sysdig.proxy.host`](#sysdigproxyhost) is listening on. If this is not
+configured it defaults to 80.<br>
+**Options**:<br>
+**Default**: `80`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    port: 3128
+```
+
+## **sysdig.proxy.protocol**
+**Required**: `false`<br>
+**Description**: The protocol to use to communicate with the configured
+[`sysdig.proxy.host`](#sysdigproxyhost).<br>
+**Options**: `http|https`<br>
+**Default**: `http`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    protocol: https
+```
+
+## **sysdig.proxy.user**
+**Required**: `false`<br>
+**Description**: The user used to access the configured
+[`sysdig.proxy.host`](#sysdigproxyhost).<br>
+**Options**:<br>
+**Default**:<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  proxy:
+    enable: true
+    user: alice
+```
+## **sysdig.slack.client.id**
+**Required**: `false`<br>
+**Description**: Your Slack application client_id, needed for Sysdig Platform to send Slack notifications <br>
+**Options**:<br>
+**Default**: `awesomeclientid`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  slack:
+    client: 
+      id: 2255883163.123123123534
+```
+
+## **sysdig.slack.client.secret**
+**Required**: `false`<br>
+**Description**: Your Slack application client_secret, needed for Sysdig Platform to send Slack notifications <br>
+**Options**:<br>
+**Default**: `awesomeclientsecret`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  slack:
+    client: 
+      secret: 8a8af18123128acd312d12d12da
+```
+
+## **sysdig.slack.client.scope**
+**Required**: `false`<br>
+**Description**: Your Slack application scope, needed for Sysdig Platform to send Slack notifications <br>
+**Options**:<br>
+**Default**: `incoming-webhook`<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  slack:
+    client: 
+      scope: incoming-webhook
+```
+
+## **sysdig.slack.client.endpoint**
+**Required**: `false`<br>
+**Description**: Your Slack application authorization endpoint, needed for Sysdig Platform to send Slack notifications <br>
+**Options**:<br>
+**Default**: `https://slack.com/oauth/v2/authorize` <br>
+
+**Example**:
+
+```yaml
+sysdig:
+  slack:
+    client: 
+      endpoint: https://slack.com/oauth/v2/authorize
+```
+
+## **sysdig.slack.client.oauth.endpoint**
+**Required**: `false`<br>
+**Description**: Your Slack application oauth endpoint, needed for Sysdig Platform to send Slack notifications <br>
+**Options**:<br>
+**Default**: `https://slack.com/api/oauth.v2.access` <br>
+
+**Example**:
+
+```yaml
+sysdig:
+  slack:
+    client: 
+      oauth:
+        endpoint: https://slack.com/api/oauth.v2.access
+```
+
+## **sysdig.inactivitySettings.trackerEnabled**
+**Required**: `false`<br>
+**Description**: Enables inactivity tracker. If the user performed no actions, they will be logged out automatically.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+
+**Example**:
+```yaml
+sysdig:
+  inactivitySettings:
+    trackerEnabled: true
+```
+
+## **sysdig.inactivitySettings.trackerTimeout**
+**Required**: `false`<br>
+**Description**: Sets the timeout value (in seconds) for inactivity tracker.<br>
+**Options**: `60-1209600`<br>
+**Default**: `1800`<br>
+
+**Example**:
+```yaml
+sysdig:
+  inactivitySettings:
+    trackerTimeout: 900
+```
+
+
+## **sysdig.secure.anchore.customCerts**
+**Required**: `false`<br>
+**Description**:
+To allow the Anchore to trust these certificates, use this configuration to upload one or more PEM-format CA certificates. You must ensure you've uploaded all certificates in the CA approval chain to the root CA.
+
+This configuration when set expects certificates with .crt, .pem extension under certs/anchore-custom-certs/ in the same level as `values.yaml`<br>
+**Options**: `true|false`<br>
+**Default**: false<br>
+**Example**:
+
+```bash
+#In the example directory structure below, certificate1.crt and certificate2.crt will be added to the trusted list.
+bash-5.0$ find certs values.yaml
+certs
+certs/anchore-custom-certs
+certs/anchore-custom-certs/certificate1.crt
+certs/anchore-custom-certs/certificate2.crt
+values.yaml
+```
+
+```yaml
+sysdig:
+  secure:
+    anchore:
+      customCerts: true
+```
+
+## **sysdig.redisVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of Redis.<br>
+**Options**:<br>
+**Default**: 4.0.12.7<br>
+**Example**:
+
+```yaml
+sysdig:
+  redisVersion: 4.0.12.7
+```
+
+## **sysdig.redisHaVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of HA Redis, relevant when configured
+`sysdig.redisHa` is `true`.<br>
+**Options**:<br>
+**Default**: 4.0.12-1.0.1<br>
+**Example**:
+
+```yaml
+sysdig:
+  redisHaVersion: 4.0.12-1.0.1
+```
+
+## **sysdig.redisHa**
+**Required**: `false`<br>
+**Description**: Determines if redis should run in HA mode<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  redisHa: false
+```
+
+## **sysdig.resources.cassandra.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to cassandra pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 4      |
+| large        | 8      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    cassandra:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.cassandra.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to cassandra pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 8Gi    |
+| medium       | 8Gi    |
+| large        | 8Gi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    cassandra:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.cassandra.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule cassandra pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 2        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    cassandra:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.cassandra.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule cassandra pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 2Gi      |
+| medium       | 2Gi      |
+| large        | 2Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    cassandra:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.elasticsearch.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to elasticsearch pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 4      |
+| large        | 8      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    elasticsearch:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.elasticsearch.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to elasticsearch pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 8Gi    |
+| medium       | 8Gi    |
+| large        | 8Gi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    elasticsearch:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.elasticsearch.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule elasticsearch pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 2        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    elasticsearch:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.elasticsearch.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule elasticsearch pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 4Gi      |
+| medium       | 4Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    elasticsearch:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.mysql-router.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to mysql-router pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500m   |
+| medium       | 500m   |
+| large        | 500m   |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql-router:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.mysql-router.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to mysql-router pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql-router:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.mysql-router.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule mysql-router pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql-router:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.mysql-router.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule mysql-router pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 100Mi    |
+| medium       | 100Mi    |
+| large        | 100Mi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql-router:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.mysql.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to mysql pods<br>
+**Options**:<br>
+**Default**:<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.mysql.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to mysql pods<br>
+**Options**:<br>
+**Default**:<br>
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.mysql.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule mysql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 500m     |
+| large        | 500m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.mysql.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule mysql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    mysql:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.postgresql.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to postgresql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    postgresql:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.postgresql.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to postgresql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 8Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    postgresql:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.postgresql.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule postgresql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 2        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    postgresql:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.postgresql.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule postgresql pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500Mi    |
+| medium       | 1Gi      |
+| large        | 2Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    postgresql:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.redis.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to redis pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.redis.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to redis pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2Gi    |
+| medium       | 2Gi    |
+| large        | 2Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis:
+      limits:
+        memory: 1Gi
+```
+
+## **sysdig.resources.redis.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule redis pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 100m     |
+| medium       | 100m     |
+| large        | 100m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.redis.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule redis pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 100Mi    |
+| medium       | 100Mi    |
+| large        | 100Mi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.redis-sentinel.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 300m   |
+| medium       | 300m   |
+| large        | 300m   |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.redis-sentinel.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 20Mi   |
+| medium       | 20Mi   |
+| large        | 20Mi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.redis-sentinel.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50m      |
+| medium       | 50m      |
+| large        | 50m      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.redis-sentinel.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 5Mi      |
+| medium       | 5Mi      |
+| large        | 5Mi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.redis-sentinel.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 300m   |
+| medium       | 300m   |
+| large        | 300m   |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.redis-sentinel.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 20Mi   |
+| medium       | 20Mi   |
+| large        | 20Mi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.redis-sentinel.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50m      |
+| medium       | 50m      |
+| large        | 50m      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.redis-sentinel.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule redis-sentinel pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 5Mi      |
+| medium       | 5Mi      |
+| large        | 5Mi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    redis-sentinel:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.timescale-adapter.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to timescale-adapter containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 16     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    timescale-adapter:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.timescale-adapter.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to timescale-adapter containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 16Gi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    timescale-adapter:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.timescale-adapter.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule timescale-adapter containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 1        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    timescale-adapter:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.timescale-adapter.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule timescale-adapter containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    timescale-adapter:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 16     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    api:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 16Gi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    api:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 1        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    api:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    api:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.worker.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 8      |
+| large        | 16     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    worker:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.worker.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 8Gi    |
+| large        | 16Gi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    worker:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.worker.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 2        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    worker:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.worker.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 2Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    worker:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.alerter.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to alerter pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 8      |
+| large        | 16     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    alerter:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.alerter.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to alerter pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 8Gi    |
+| large        | 16Gi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    alerter:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.alerter.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule alerter pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 2        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    alerter:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.alerter.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule alerter pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 2Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    alerter:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.collector.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to collector pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 16     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    collector:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.collector.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to collector pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 16Gi   |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    collector:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.collector.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule collector pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 1        |
+| large        | 4        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    collector:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.collector.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule collector pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 4Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    collector:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.anchore-core.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to anchore-core pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-core:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.anchore-core.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to anchore-core pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-core:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.anchore-core.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule anchore-core pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-core:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.anchore-core.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule anchore-core pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-core:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.anchore-worker.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to anchore-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-worker:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.anchore-worker.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to anchore-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-worker:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.anchore-worker.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule anchore-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-worker:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.anchore-worker.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule anchore-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    anchore-worker:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.scanning-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to scanning-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-api:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to scanning-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-api:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.scanning-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule scanning-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-api:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule scanning-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-api:
+      requests:
+        memory: 200Mi
+```
+
+
+## **sysdig.resources.scanningalertmgr.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to scanningalertmgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanningalertmgr:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.scanningalertmgr.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to scanningalertmgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanningalertmgr:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.scanningalertmgr.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule scanningalertmgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanningalertmgr:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.scanningalertmgr.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule scanningalertmgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanningalertmgr:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.scanning-retention-mgr.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to scanning retention-mgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-retention-mgr:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-retention-mgr.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to scanning retention-mgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-retention-mgr:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.scanning-retention-mgr.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule scanning retention-mgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-retention-mgr:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-retention-mgr.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule scanning retention-mgr pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-retention-mgr:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.secure.scanning.retentionMgr.cronjob**
+**Required**: `false`<br>
+**Description**: Retention manager Cronjob<br>
+**Options**:<br>
+**Default**: 0 3 * * *<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        cronjob: 0 3 * * *
+```
+
+## **sysdig.secure.scanning.retentionMgr.retentionPolicyMaxExecutionDuration**
+**Required**: `false`<br>
+**Description**: Max execution duration for the retention policy<br>
+**Options**:<br>
+**Default**: 23h<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        retentionPolicyMaxExecutionDuration: 23h
+```
+
+## **sysdig.secure.scanning.retentionMgr.retentionPolicyGracePeriodDuration**
+**Required**: `false`<br>
+**Description**: Grace period for the retention policy<br>
+**Options**:<br>
+**Default**: 168h<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        retentionPolicyGracePeriodDuration: 168h
+```
+
+## **sysdig.secure.scanning.retentionMgr.retentionPolicyArtificialDelayAfterDelete**
+**Required**: `false`<br>
+**Description**: Artifical delay after each image deletion<br>
+**Options**:<br>
+**Default**: 1s<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        retentionPolicyArtificialDelayAfterDelete: 1s
+```
+
+## **sysdig.secure.scanning.retentionMgr.scanningGRPCEndpoint**
+**Required**: `false`<br>
+**Description**: Scanning GRPC endpoint<br>
+**Options**:<br>
+**Default**: sysdigcloud-scanning-api:6000<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        scanningGRPCEndpoint: sysdigcloud-scanning-api:6000
+```
+
+## **sysdig.secure.scanning.retentionMgr.scanningDBEngine**
+**Required**: `false`<br>
+**Description**: Scanning DB engine<br>
+**Options**:<br>
+**Default**: mysql<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        scanningDBEngine: mysql
+```
+
+## **sysdig.secure.scanning.retentionMgr.defaultValues.datePolicy**
+**Required**: `false`<br>
+**Description**: Default value for the date policy<br>
+**Options**:<br>
+**Default**: 90<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        defaultValues:
+          datePolicy: 90
+```
+
+## **sysdig.secure.scanning.retentionMgr.defaultValues.tagsPolicy**
+**Required**: `false`<br>
+**Description**: Default value for the tags policy<br>
+**Options**:<br>
+**Default**: 5<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        defaultValues:
+          tagsPolicy: 5
+```
+
+## **sysdig.secure.scanning.retentionMgr.defaultValues.digestsPolicy**
+**Required**: `false`<br>
+**Description**: Default value for the digests policy<br>
+**Options**:<br>
+**Default**: 5<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanning:
+      retentionMgr:
+        defaultValues:
+          digestsPolicy: 5
+```
+
+## **sysdig.resources.scanning-ve-janitor.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to scanning-ve-janitor cronjob<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 300m   |
+| medium       | 500m   |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-ve-janitor:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-ve-janitor.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to scanning-ve-janitor cronjob<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 256Mi  |
+| medium       | 2Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-ve-janitor:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.scanning-ve-janitor.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule scanning-ve-janitor cronjob<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 100m     |
+| medium       | 100m     |
+| large        | 100m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-ve-janitor:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.scanning-ve-janitor.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule scanning-ve-janitor cronjob<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 256Mi    |
+| medium       | 256Mi    |
+| large        | 256Mi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    scanning-ve-janitor:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.policy-advisor.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to policy-advisor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4      |
+| medium       | 4      |
+| large        | 4      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    policy-advisor:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.policy-advisor.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to policy-advisor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 4Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    policy-advisor:
+      limits:
+        memory: 10Mi
+```
+
+## **sysdig.resources.policy-advisor.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule policy-advisor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    policy-advisor:
+      requests:
+        cpu: 2
+```
+
+## **sysdig.resources.policy-advisor.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule policy-advisor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    policy-advisor:
+      requests:
+        memory: 200Mi
+```
+
+## **sysdig.resources.netsec-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to netsec-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-api:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.netsec-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to netsec-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1Gi    |
+| medium       | 2Gi    |
+| large        | 2Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-api:
+      limits:
+        memory: 1Gi
+```
+
+## **sysdig.resources.netsec-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule netsec-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 300m     |
+| medium       | 500m     |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-api:
+      requests:
+        cpu: 300m
+```
+
+## **sysdig.resources.netsec-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule netsec-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-api:
+      requests:
+        memory: 1Gi
+```
+
+## **sysdig.resources.netsec-ingest.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to netsec-ingest pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-ingest:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.netsec-ingest.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to netsec-ingest pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 4Gi    |
+| medium       | 6Gi    |
+| large        | 8Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-ingest:
+      limits:
+        memory: 4Gi
+```
+
+## **sysdig.resources.netsec-ingest.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule netsec-ingest pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 1        |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-ingest:
+      requests:
+        cpu: 500m
+```
+
+## **sysdig.resources.netsec-ingest.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule to netsec-ingest pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1Gi    |
+| medium       | 2Gi    |
+| large        | 4Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-ingest:
+      limits:
+        memory: 2Gi
+```
+
+## **sysdig.resources.netsec-janitor.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to netsec-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-janitor:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.netsec-janitor.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to netsec-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1Gi    |
+| medium       | 2Gi    |
+| large        | 2Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-janitor:
+      limits:
+        memory: 1Gi
+```
+
+## **sysdig.resources.netsec-janitor.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule netsec-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 300m     |
+| medium       | 500m     |
+| large        | 1        |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-janitor:
+      requests:
+        cpu: 1
+```
+
+## **sysdig.resources.netsec-janitor.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule netsec-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    netsec-janitor:
+      requests:
+        memory: 1Gi
+```
+
+## **sysdig.resources.nats-streaming.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to nats-streaming pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    nats-streaming:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.nats-streaming.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to nats-streaming pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2Gi    |
+| medium       | 2Gi    |
+| large        | 2Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    nats-streaming:
+      limits:
+        memory: 2Gi
+```
+
+## **sysdig.resources.nats-streaming.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule nats-streaming pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    nats-streaming:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.nats-streaming.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule nats-streaming pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 1Gi      |
+| large        | 1Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    nats-streaming:
+      requests:
+        memory: 1Gi
+```
+
+## **sysdig.resources.activity-audit-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to activity-audit-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-api:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.activity-audit-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to activity-audit-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-api:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.activity-audit-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule activity-audit-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-api:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.activity-audit-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule activity-audit-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-api:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.activity-audit-worker.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to activity-audit-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-worker:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.activity-audit-worker.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to activity-audit-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-worker:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.activity-audit-worker.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule activity-audit-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-worker:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.activity-audit-worker.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule activity-audit-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-worker:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.activity-audit-janitor.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to activity-audit-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 250m   |
+| medium       | 250m   |
+| large        | 250m   |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-janitor:
+      limits:
+        cpu: 250m
+```
+
+## **sysdig.resources.activity-audit-janitor.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to activity-audit-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 200Mi  |
+| medium       | 200Mi  |
+| large        | 200Mi  |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-janitor:
+      limits:
+        memory: 200Mi
+```
+
+## **sysdig.resources.activity-audit-janitor.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule activity-audit-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-janitor:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.activity-audit-janitor.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule activity-audit-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    activity-audit-janitor:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.profiling-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to profiling-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-api:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.profiling-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to profiling-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-api:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.profiling-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule profiling-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-api:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.profiling-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule profiling-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-api:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.profiling-worker.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to profiling-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-worker:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.profiling-worker.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to profiling-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-worker:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.profiling-worker.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule profiling-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-worker:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.profiling-worker.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule profiling-worker pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    profiling-worker:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.secure-overview-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to secure-overview-api containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-overview-api:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.secure-overview-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to secure-overview-api containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1Gi    |
+| medium       | 1Gi    |
+| large        | 1Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-overview-api:
+      limits:
+        memory: 1Gi
+```
+
+## **sysdig.resources.secure-overview-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule secure-overview-api containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 500m     |
+| large        | 500m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-overview-api:
+      requests:
+        cpu: 500m
+```
+
+## **sysdig.resources.secure-overview-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule secure-overview-api containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 512Mi    |
+| medium       | 512Mi    |
+| large        | 512Mi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-overview-api:
+      requests:
+        memory: 512Mi
+```
+
+## **sysdig.resources.secure-prometheus.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to secure-prometheus containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-prometheus:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.secure-prometheus.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to secure-prometheus containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 8Gi    |
+| medium       | 8Gi    |
+| large        | 8Gi    |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-prometheus:
+      limits:
+        memory: 8Gi
+```
+
+## **sysdig.resources.secure-prometheus.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule secure-prometheus containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 500m     |
+| medium       | 500m     |
+| large        | 500m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-prometheus:
+      requests:
+        cpu: 500m
+```
+
+## **sysdig.resources.secure-prometheus.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule secure-prometheus containers<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 2Gi      |
+| medium       | 2Gi      |
+| large        | 2Gi      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    secure-prometheus:
+      requests:
+        memory: 2Gi
+```
+
+## **sysdig.resources.events-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-api:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.events-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-api:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.events-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-api:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-api:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.events-gatherer.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-gatherer pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 2      |
+| medium       | 2      |
+| large        | 2      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-gatherer:
+      limits:
+        cpu: 2
+```
+
+## **sysdig.resources.events-gatherer.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-gatherer pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1Gi    |
+| medium       | 1Gi    |
+| large        | 1Gi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-gatherer:
+      limits:
+        memory: 1Gi
+```
+
+## **sysdig.resources.events-gatherer.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-gatherer pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-gatherer:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-gatherer.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-gatherer pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250Mi    |
+| medium       | 250Mi    |
+| large        | 250Mi    |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-gatherer:
+      requests:
+        memory: 250Mi
+```
+
+## **sysdig.resources.events-dispatcher.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-dispatcher pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-dispatcher:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.events-dispatcher.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-dispatcher pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 250Mi  |
+| medium       | 250Mi  |
+| large        | 250Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-dispatcher:
+      limits:
+        memory: 250Mi
+```
+
+## **sysdig.resources.events-dispatcher.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-dispatcher pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-dispatcher:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-dispatcher.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-dispatcher pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-dispatcher:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.events-forwarder-api.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-forwarder-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder-api:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.events-forwarder-api.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-forwarder-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder-api:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.events-forwarder-api.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-forwarder-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder-api:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-forwarder-api.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-forwarder-api pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder-api:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.resources.events-forwarder.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-forwarder pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.events-forwarder.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-forwarder pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 500Mi  |
+| medium       | 500Mi  |
+| large        | 500Mi  |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder:
+      limits:
+        memory: 500Mi
+```
+
+## **sysdig.resources.events-forwarder.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-forwarder pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-forwarder.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-forwarder pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-forwarder:
+      requests:
+        memory:  50Mi
+```
+
+## **sysdig.resources.events-janitor.limits.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu assigned to events-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 1      |
+| medium       | 1      |
+| large        | 1      |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-janitor:
+      limits:
+        cpu: 1
+```
+
+## **sysdig.resources.events-janitor.limits.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory assigned to events-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 200Mi  |
+| medium       | 200Mi  |
+| large        | 200Mi  |
+
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-janitor:
+      limits:
+        memory: 200Mi
+```
+
+## **sysdig.resources.events-janitor.requests.cpu**
+**Required**: `false`<br>
+**Description**: The amount of cpu required to schedule events-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 250m     |
+| medium       | 250m     |
+| large        | 250m     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-janitor:
+      requests:
+        cpu: 250m
+```
+
+## **sysdig.resources.events-janitor.requests.memory**
+**Required**: `false`<br>
+**Description**: The amount of memory required to schedule events-janitor pods<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 50Mi     |
+| medium       | 50Mi     |
+| large        | 50Mi     |
+
+**Example**:
+
+```yaml
+sysdig:
+  resources:
+    events-janitor:
+      requests:
+        memory: 50Mi
+```
+
+## **sysdig.restrictPasswordLogin**
+**Required**: `false`<br>
+**Description**: Restricts password login to only super admin user forcing all
+non-default users to login using the configured
+[IdP](https://en.wikipedia.org/wiki/Identity_provider).<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+sysdig:
+  restrictPasswordLogin: true
+```
+
+## **sysdig.rsyslogVersion**
+**Required**: `false`<br>
+**Description**: Docker image tag of rsyslog, relevant only when configured
+`deployment` is `kubernetes`.<br>
+**Options**:<br>
+**Default**: 8.34.0.7<br>
+**Example**:
+
+```yaml
+sysdig:
+  rsyslogVersion: 8.34.0.7
+```
+
+## **sysdig.smtpFromAddress**
+**Required**: `false`<br>
+**Description**: Email address to use for the FROM field of sent emails.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpFromAddress: from-address@my-company.com
+```
+
+## **sysdig.smtpPassword**
+**Required**: `false`<br>
+**Description**: Password for the configured `sysdig.smtpUser`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpPassword: my-@w350m3-p@55w0rd
+```
+
+## **sysdig.smtpProtocolSSL**
+**Required**: `false`<br>
+**Description**: Specifies if SSL should be used when sending emails via SMTP.<br>
+**Options**: `true|false` <br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpProtocolSSL: true
+```
+
+## **sysdig.smtpProtocolTLS**
+**Required**: `false`<br>
+**Description**: Specifies if TLS should be used when sending emails via SMTP<br>
+**Options**: `true|false` <br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpProtocolTLS: true
+```
+
+## **sysdig.smtpServer**
+**Required**: `false`<br>
+**Description**: SMTP server to use to send emails<br>
+**Options**: <br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpServer: smtp.gmail.com
+```
+
+## **sysdig.smtpServerPort**
+**Required**: `false`<br>
+**Description**: Port of the configured `sysdig.smtpServer`<br>
+**Options**: `1-65535`<br>
+**Default**: `25`<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpServerPort: 587<br>
+```
+
+## **sysdig.smtpUser**
+**Required**: `false`<br>
+**Description**: User for the configured `sysdig.smtpServer`<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  smtpUser: bob+alice@gmail.com<br>
+```
+
+## **sysdig.tolerations**
+**Required**: `false`<br>
+**Description**:
+[Toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+that will be created on Sysdig platform pods, this can be combined with
+[nodeaffinityLabel.key](#nodeaffinityLabelkey) and
+[nodeaffinityLabel.value](#nodeaffinityLabelvalue) to ensure only Sysdig
+Platform pods run on particular nodes<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: sysdig
+      effect: "NoSchedule"
+```
+
+## **sysdig.anchoreCoreReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig Anchore Core replicas, this is a noop for
+clusters of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  anchoreCoreReplicaCount: 5
+```
+
+## **sysdig.anchoreWorkerReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig Anchore Worker replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  anchoreWorkerReplicaCount: 5
+```
+
+## **sysdig.apiReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig API replicas, this is a noop for clusters of
+`size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 5     |
+
+**Example**:
+
+```yaml
+sysdig:
+  apiReplicaCount: 5
+```
+
+## **sysdig.cassandraReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Cassandra replicas, this is a noop for clusters of
+`size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 6     |
+
+**Example**:
+
+```yaml
+sysdig:
+  cassandraReplicaCount: 20
+```
+
+## **sysdig.collectorReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig collector replicas, this is a noop for
+clusters of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 5     |
+
+**Example**:
+
+```yaml
+sysdig:
+  collectorReplicaCount: 7
+```
+
+## **sysdig.activityAuditWorkerReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Activity Audit Worker replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 2     |
+| large        | 4     |
+
+**Example**:
+
+```yaml
+sysdig:
+  activityAuditWorkerReplicaCount: 20
+```
+
+## **sysdig.activityAuditApiReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Activity Audit API replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  activityAuditApiReplicaCount: 20
+```
+
+## **sysdig.policyAdvisorReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Policy Advisor replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  policyAdvisorReplicaCount: 20
+```
+
+## **sysdig.netsecApiReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Netsec API replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  netsecApiReplicaCount: 1
+```
+
+## **sysdig.netsecIngestReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Netsec Ingest replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  netsecIngestReplicaCount: 1
+```
+
+## **sysdig.anchoreCoreReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Anchore Core replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  anchoreCoreReplicaCount: 2
+```
+
+## **sysdig.scanningApiReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Scanning API replicas.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  scanningApiReplicaCount: 3
+```
+
+## **sysdig.elasticsearchReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of ElasticSearch replicas, this is a noop for clusters of
+`size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 6     |
+
+**Example**:
+
+```yaml
+sysdig:
+  elasticsearchReplicaCount: 20
+```
+
+## **sysdig.workerReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig worker replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 5     |
+
+**Example**:
+
+```yaml
+sysdig:
+  workerReplicaCount: 7
+```
+
+## **sysdig.alerterReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of Sysdig alerter replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 3     |
+| large        | 5     |
+
+**Example**:
+
+```yaml
+sysdig:
+  alerterReplicaCount: 7
+```
+
+## **sysdig.eventsGathererReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of events gatherer replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 2     |
+| large        | 4     |
+
+**Example**:
+
+```yaml
+sysdig:
+  eventsGathererReplicaCount: 2
+```
+
+## **sysdig.eventsAPIReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of events API replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  eventsAPIReplicaCount: 1
+```
+
+## **sysdig.eventsDispatcherReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of events dispatcher replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  eventsDispatcherReplicaCount: 1
+```
+
+## **sysdig.eventsForwarderReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of events forwarder replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 2     |
+
+**Example**:
+
+```yaml
+sysdig:
+  eventsForwarderReplicaCount: 2
+```
+
+## **sysdig.eventsForwarderAPIReplicaCount**
+**Required**: `false`<br>
+**Description**: Number of events forwarder API replicas, this is a noop for clusters
+of `size` `small`.<br>
+**Options**:<br>
+**Default**:<br>
+
+| cluster-size | count |
+| ------------ | ----- |
+| small        | 1     |
+| medium       | 1     |
+| large        | 1     |
+
+**Example**:
+
+```yaml
+sysdig:
+  eventsForwarderAPIReplicaCount: 1
+```
+
+## **sysdig.admin.username**
+**Required**: `true`<br>
+**Description**: Sysdig Platform super admin user. This will be used for
+initial login to the web interface. Make sure this is a valid email address
+that you can receive emails at.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  admin:
+    username: my-awesome-email@my-awesome-domain-name.com
+```
+
+## **sysdig.admin.password**
+**Required**: `false`<br>
+**Description**: Sysdig Platform super admin password. This along with
+`sysdig.admin.username` will be used for initial login to the web interface.
+It is auto-generated when not explicitly configured.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  admin:
+    password: my-@w350m3-p@55w0rd
+```
+
+## **sysdig.api.jvmOptions**
+**Required**: `false`<br>
+**Description**: Custom configuration for Sysdig API jvm.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  api:
+    jvmOptions: -Xms4G -Xmx4G -Ddraios.jvm-monitoring.ticker.enabled=true
+      -XX:-UseContainerSupport -Ddraios.metrics-push.query.enabled=true
+```
+
+## **sysdig.certificate.generate**
+**Required**: `false`<br>
+**Description**: Determines if Installer should generate self-signed
+certificates for the domain configured in `sysdig.dnsName`.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+sysdig:
+  certificate:
+    generate: true
+```
+
+## **sysdig.certificate.crt**
+**Required**: `false`<br>
+**Description**: Path(the path must be in same directory as `values.yaml` file
+and must be relative to `values.yaml`) to user provided certificate that will
+be used in serving the Sysdig api, if `sysdig.certificate.generate` is set to
+`false` this has to be configured. The certificate common name or subject
+altername name must match configured `sysdig.dnsName`.<br>
+**Options**:<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+sysdig:
+  certificate:
+    crt: certs/server.crt
+```
+
+## **sysdig.certificate.key**
+**Required**: `false`<br>
+**Description**: Path(the path must be in same directory as `values.yaml` file
+and must be relative to `values.yaml`) to user provided key that will be used
+in serving the sysdig api, if `sysdig.certificate.generate` is set to `false`
+this has to be configured. The key must match the certificate in
+`sysdig.certificate.crt`.<br>
+**Options**:<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+sysdig:
+  certificate:
+    key: certs/server.key
+```
+
+## **sysdig.collector.dnsName**
+**Required**: `false`<br>
+**Description**: Domain name the Sysdig collector will be served on, when not
+configured it defaults to whatever is configured for `sysdig.dnsName`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  collector:
+    dnsName: collector.my-awesome-domain-name.com
+```
+
+## **sysdig.collector.jvmOptions**
+**Required**: `false`<br>
+**Description**: Custom configuration for Sysdig collector jvm.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  collector:
+    jvmOptions: -Xms4G -Xmx4G -Ddraios.jvm-monitoring.ticker.enabled=true
+      -XX:-UseContainerSupport
+```
+
+## **sysdig.collector.certificate.generate**
+**Required**: `false`<br>
+**Description**: This determines if Installer should generate self-signed<br>
+certificates for the domain configured in `sysdig.collector.dnsName`.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+sysdig:
+  collector:
+    certificate:
+      generate: true
+```
+
+## **sysdig.collector.certificate.crt**
+**Required**: `false`<br>
+**Description**: Path(the path must be in same directory as `values.yaml` file
+and must be relative to `values.yaml`) to user provided certificate that will
+be used in serving the sysdig collector, if
+`sysdig.collector.certificate.generate` is set to `false` this has to be
+configured. The certificate common name or subject altername name must match
+configured `sysdig.collector.dnsName`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  collector:
+    certificate:
+      crt: certs/collector.crt
+```
+
+## **sysdig.collector.certificate.key**
+**Required**: `false`<br>
+**Description**: Path(the path must be in same directory as `values.yaml` file
+and must be relative to `values.yaml`) to user provided key that will be used
+in serving the sysdig collector, if `sysdig.collector.certificate.generate` is
+set to `false` this has to be configured. The key must match the certificate
+in `sysdig.collector.certificate.crt`.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  collector:
+    certificate:
+      key: certs/collector.key
+```
+
+## **sysdig.worker.jvmOptions**
+**Required**: `false`<br>
+**Description**: Custom configuration for Sysdig worker jvm.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  worker:
+    jvmOptions: -Xms4G -Xmx4G -Ddraios.jvm-monitoring.ticker.enabled=true
+      -XX:-UseContainerSupport
+```
+
+## **sysdig.alerter.jvmOptions**
+**Required**: `false`<br>
+**Description**: Custom configuration for Sysdig Alerter jvm.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+sysdig:
+  alerter:
+    jvmOptions: -Xms4G -Xmx4G -Ddraios.jvm-monitoring.ticker.enabled=true
+      -XX:-UseContainerSupport
+```
+
+## **agent.apiKey**
+**Required**: `false`<br>
+**Description**: Sysdig Agent api key for running agents. Instructions for retrieving the api key can be found [here](https://docs.sysdig.com/en/agent-installation--overview-and-key.html).<br>
+_**Note**: Required for agent setup. If setting up Monitor and Agent at the same time, you can leave this as blank._<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+agent:
+  apiKey: replace_with_your_monitor_access_key
+```
+
+## **agent.appChecks.settings.limit**
+**Required**: `false`<br>
+**Description**: The maximum number of app checks metrics that will be reported to Sysdig Monitor.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    settings:
+      limit: 1500
+```
+
+## **agent.collectorEndpoint**
+**Required**: `false`<br>
+**Description**: Sysdig Collector Address. Defaults to [`sysdig.collector.dnsName`](#sysdig.collector.dnsName) if monitor is included in apps.<br>
+**Options**:<br>
+**Default**:<br>
+**Example**:
+
+```yaml
+agent:
+  collectorEndpoint: my-awesome-collector-domain-name.com
+```
+
+## **agent.collectorPort**
+**Required**: `false`<br>
+**Description**: Sysdig Colletor TCP Port.<br>
+**Options**: `1024-65535`<br>
+**Default**: `6443`<br>
+**Example**:
+
+```yaml
+agent:
+  collectorPort: 6443
+```
+
+## **agent.namespace**
+**Required**: `false`<br>
+**Description**: A kubernetes namespace for setting up the agent in.<br>
+**Options**: <br>
+**Default**: `agent`<br>
+**Example**:
+
+```yaml
+agent:
+  namespace: sysdig-agent
+```
+
+## **agent.useSlim**
+**Required**: `false`<br>
+**Description**: Whether to use the slim version of agent or not.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  useSlim: true
+```
+
+## **agent.version**
+**Required**: `false`<br>
+**Description**: Version of agent to install.<br>
+_**Note**: You can lookup all the available versions of agent [here](https://hub.docker.com/r/sysdig/agent/tags)_<br>
+**Options**: <br>
+**Default**: `latest`<br>
+**Example**:
+
+```yaml
+agent:
+  version: 1.10.1
+```
+
+## **agent.useSSL**
+**Required**: `false`<br>
+**Description**: Whether Sysdig Collector accepts SSL connections or not.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  useSSL: false
+```
+
+## **agent.verifySSL**
+**Required**: `false`<br>
+**Description**: Whether to validate Sysdig Collector SSL certificate or not.<br>
+_**Note**: This should be set to false if a self-signed certificate or private, CA-signed cert is used._<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  verifySSL: false
+```
+
+## **agent.clusterName**
+**Required**: `false`<br>
+**Description**: Setting a cluster name here allows you to view, scope, and segment metrics in the Sysdig Monitor UI by Kubernetes cluster.<br>
+**Options**: <br>
+**Default**: `production`<br>
+**Example**:
+
+```yaml
+agent:
+  clusterName: false
+```
+
+## **agent.tags**
+**Required**: `false`<br>
+**Description**: List of user-provided metadata at agent level.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  tags: environment:production linux:ubuntu
+```
+
+## **agent.capturesEnabled**
+**Required**: `false`<br>
+**Description**: TBD.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  capturesEnabled: false
+```
+
+## **agent.feature_mode**
+**Required**: `false`<br>
+**Description**: TBD.<br>
+**Options**: `monitor|monitor_light|essentials|troubleshooting|secure`<br>
+**Default**: `monitor`<br>
+**Example**:
+
+```yaml
+agent:
+  feature_mode: troubleshooting
+```
+
+## **agent.timezone**
+**Required**: `false`<br>
+**Description**: Set daemonset timezone.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  timezone: America/New_York.
+```
+
+## **agent.proxy.httpProxy**
+**Required**: `false`<br>
+**Description**: The URL to use as a proxy for http requests. If the proxy requires authentication, you need to specify this information as part of the URL.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  proxy:
+    httpProxy: http://username:password@your-awesome-http-proxy.com
+```
+
+## **agent.proxy.httpsProxy**
+**Required**: `false`<br>
+**Description**: The URL to use as a proxy for https requests. If the proxy requires authentication, you need to specify this information as part of the URL.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  proxy:
+    httpsProxy: https://username:password@your-awesome-https-proxy.com
+```
+
+## **agent.proxy.noProxy**
+**Required**: `false`<br>
+**Description**: A space-separated list of URLs for which no proxy should be used.<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  proxy:
+    noProxy: your-awesome-no-proxy.com
+```
+
+## **agent.snaplenPortRange.start**
+**Required**: `false`<br>
+**Description**: Starting port in the range of ports to enable a larger snaplen on.<br>
+_**Note**: This should only be set if you push a lot of statsd metrics._<br>
+**Options**: <br>
+**Default**: `0`<br>
+**Example**:
+
+```yaml
+agent:
+  snaplenPortRange:
+    start: "8125"
+```
+
+## **agent.snaplenPortRange.end**
+**Required**: `false`<br>
+**Description**: Ending port in the range of ports to enable a larger snaplen on.<br>
+_**Note**: This should only be set if you push a lot of statsd metrics._<br>
+**Options**: <br>
+**Default**: `0`<br>
+**Example**:
+
+```yaml
+agent:
+  snaplenPortRange:
+    start: "8125"
+```
+
+## **agent.customKernelModules.enabled**
+**Required**: `false`<br>
+**Description**: Whether to pick up custom kernel modules from /root or not. This setting only applies to non-slim agent.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  customKernelModules:
+    enabled: true
+```
+
+## **agent.secure.enabled**
+**Required**: `false`<br>
+**Description**: Whether your Sysdig platform has Sysdig Secure enabled or not.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  secure:
+    enabled: true
+```
+
+## **agent.secure.commandLineCapturesEnabled**
+**Required**: `false`<br>
+**Description**: Whether you want to enable Command Line Captures or not.<br>
+_**Note**: This setting is dependent on `agent.secure.enabled` being set to `true`._<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  secure:
+    commandLineCapturesEnabled: true
+```
+
+## **agent.secure.memoryDumpEnabled**
+**Required**: `false`<br>
+**Description**: Whether you want to enable Memory Dump or not.<br>
+_**Note**: This setting is dependent on `agent.secure.enabled` being set to `true`._<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  secure:
+    memoryDumpEnabled: true
+```
+
+## **agent.secure.settings.k8sAuditServerURL**
+**Required**: `false`<br>
+**Description**: Kubernetes Audit Server URL.<br>
+_**Note**: This setting is dependent on `agent.secure.enabled` being set to `true`._<br>
+**Options**: <br>
+**Default**: `0.0.0.0`<br>
+**Example**:
+
+```yaml
+agent:
+  secure:
+    settings:
+    k8sAuditServerURL: 127.0.0.1
+```
+
+## **agent.secure.settings.k8sAuditServerPort**
+**Required**: `false`<br>
+**Description**: Kubernetes Audit Server Port.<br>
+_**Note**: This setting is dependent on `agent.secure.enabled` being set to `true`._<br>
+**Options**: `1024-65535`<br>
+**Default**: `7765`<br>
+**Example**:
+
+```yaml
+agent:
+  secure:
+    settings:
+    k8sAuditServerPort: 7765
+```
+
+## **agent.prometheus.enabled**
+**Required**: `false`<br>
+**Description**: Whether to enable ingestion of prometheus metrics or not.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    enabled: true
+```
+
+## **agent.prometheus.settings.interval**
+**Required**: `false`<br>
+**Description**: How often (in seconds) the agent will scrape a port for prometheus metrics.<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: <br>
+**Default**: `10`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      interval: 30
+```
+
+## **agent.prometheus.settings.logErrors**
+**Required**: `false`<br>
+**Description**: Whether the Agent should log details on failed attempts to scrape eligible targets or not.<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      logErrors: true
+```
+
+## **agent.prometheus.settings.maxMetrics**
+**Required**: `false`<br>
+**Description**: The maximum number of total prometheus metrics that will be scraped across all targets. This value is the maximum per-Agent, and is a separate limit from other Custom Metrics (e.g. statsd, JMX, and other Application Checks).<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: <br>
+**Default**: `3000`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      maxMetrics: 1000
+```
+
+## **agent.prometheus.settings.maxMetricsPerProcess**
+**Required**: `false`<br>
+**Description**: The maximum number of prometheus metrics that the agent will save from a single scraped target.<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: <br>
+**Default**: `3000`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      maxMetricsPerProcess: 1000
+```
+
+## **agent.prometheus.settings.maxTagsPerMetric**
+**Required**: `false`<br>
+**Description**: The maximum number of tags per prometheus metric that the Agent will save from a scraped target.<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: <br>
+**Default**: `40`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      maxTagsPerMetric: 20
+```
+
+## **agent.prometheus.settings.histograms**
+**Required**: `false`<br>
+**Description**: Whether the Agent should scrape and report histogram metrics.<br>
+_**Note**: This setting is dependent on `agent.prometheus.enabled` being set to true._<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  prometheus:
+    settings:
+      histograms: 3000
+```
+
+## **agent.statsd.enabled**
+**Required**: `false`<br>
+**Description**: Whether to enable ingestion of statsd metrics or not.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  statsd:
+    enabled: true
+```
+
+## **agent.statsd.settings.limit**
+**Required**: `false`<br>
+**Description**: The maximum number of statsd metrics that will be reported to Sysdig Monitor.<br>
+**Options**: <br>
+**Default**: `100`<br>
+**Example**:
+
+```yaml
+agent:
+  statsd:
+    settings:
+      limit: 1000
+```
+
+## **agent.jmx.enabled**
+**Required**: `false`<br>
+**Description**: Whether to enable ingestion of jvm metrics via jmx protocol or not. If enabled, the agent will discover java virtual machines and poll them for basic jvm metrics like heap and gc as well as a few application sepecific metrics.<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  jmx:
+    enabled: true
+```
+
+## **agent.jmx.settings.limit**
+**Required**: `false`<br>
+**Description**: The total number of JMX metrics polled per host.<br>
+**Options**: <br>
+**Default**: `3000`<br>
+**Example**:
+
+```yaml
+agent:
+  jmx:
+    settings:
+      limit: 1000
+```
+
+## **agent.ebpf.enabled**
+**Required**: `false`<br>
+**Description**: Enable eBPF support for Sysdig instead of sysdig-probe kernel module.<br>
+_**Note**: This should be enabled for GKE COS as the installation of sysdig-probe kernel is not allowed._<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  ebpf:
+    enabled: true
+```
+
+## **agent.ebpf.settings.mountEtcVolume**
+**Required**: `false`<br>
+**Description**: Needed to detect which kernel version are running in Google COS.<br>
+_**Note**: This should be configured appropriately for GKE COS as the installation of sysdig-probe kernel is not allowed._<br>
+**Options**: `true|false`<br>
+**Default**: `true`<br>
+**Example**:
+
+```yaml
+agent:
+  ebpf:
+    settings:
+      mountEtcVolume: 1000
+```
+
+## **agent.appChecks.elasticsearch.authEnabled**
+**Required**: `false`<br>
+**Description**: Whether elasticsearch has auth enabled or not.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      authEnabled: true
+```
+
+## **agent.appChecks.elasticsearch.url**
+**Required**: `false`<br>
+**Description**: Elasticsearch Endpoint.<br>
+_**Note**: This should be configured if `agent.appChecks.elasticsearch.authEnabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      url: https://sysdigcloud-elasticsearch
+```
+
+## **agent.appChecks.elasticsearch.port**
+**Required**: `false`<br>
+**Description**: Elasticsearch Port.<br>
+_**Note**: This should be configured if `agent.appChecks.elasticsearch.authEnabled` is set to `true`._<br>
+**Options**: `1024-65535`<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      port: 9200
+```
+
+## **agent.appChecks.elasticsearch.username**
+**Required**: `false`<br>
+**Description**: Username to use for authentication to elasticsearch.<br>
+_**Note**: This should be configured if `agent.appChecks.elasticsearch.authEnabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      username: readonly
+```
+
+## **agent.appChecks.elasticsearch.password**
+**Required**: `false`<br>
+**Description**: Password to use for authentication to elasticsearch.<br>
+_**Note**: This should be configured if `agent.appChecks.elasticsearch.authEnabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      password: some_password
+```
+
+## **agent.appChecks.elasticsearch.verifySSL**
+**Required**: `false`<br>
+**Description**: Whether to validate Elasticsearch SSL certificate or not.<br>
+_**Note**: This should be configured if `agent.appChecks.elasticsearch.authEnabled` is set to `true`._<br>
+**Options**: `true|false`<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    elasticsearch:
+      verifySSL: false
+```
+
+## **agent.appChecks.kafka.enabled**
+**Required**: `false`<br>enabled
+**Description**: Whether to enable collection of metrics for kafka using JMX polling or not.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      enabled: true
+```
+
+## **agent.appChecks.kafka.arg**
+**Required**: `false`<br>enabled
+**Description**: Process arguments to match for Kafka<br>
+_**Note**: This should be configured if `agent.appChecks.kafka.enabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      arg: Kafka.kafka
+```
+
+## **agent.appChecks.kafka.url**
+**Required**: `false`<br>
+**Description**: Kafka Endpoint.<br>
+_**Note**: This should be configured if `agent.appChecks.kafka.enabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:enabled
+  appChecks:
+    kafka:
+      url: localhost
+```
+
+## **agent.appChecks.kafka.port**
+**Required**: `false`<br>
+**Description**: Kafka Port.<br>
+_**Note**: This should be configured if `agent.appChecks.kafka.enabled` is set to `true`._<br>
+**Options**: `1024-65535`<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      port: 9200
+```
+
+## **agent.appChecks.kafka.zk.url**
+**Required**: `false`<br>
+**Description**: Kafka Zookeeper Endpoint.<br>
+_**Note**: This should be configured if `agent.appChecks.kafka.enabled` is set to `true`._<br>
+**Options**: <br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:enabled
+  appChecks:
+    kafka:
+      zk:
+        url: localhost
+```
+
+## **agent.appChecks.kafka.zk.port**
+**Required**: `false`<br>
+**Description**: Kafka Zookeeper Port.<br>
+_**Note**: This should be configured if `agent.appChecks.kafka.enabled` is set to `true`._<br>
+**Options**: `1024-65535`<br>
+**Default**: <br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      zk:
+        port: 2181
+```
+
+## **agent.appChecks.kafka.enableConsumerOffsets**
+**Required**: `false`<br>enabled
+**Description**: Whether to store consumer group config info inside Kafka itself or not. Enabling this will provide better performance.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      enableConsumerOffsets: true
+```
+
+## **agent.appChecks.kafka.enableAggregationPartitions**
+**Required**: `false`<br>enabled
+**Description**: Whether to enable aggregation of partitions at the topic level or not.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    kafka:
+      enableAggregationPartitions: true
+```
+
+## **agent.appChecks.mysql.enabled**
+**Required**: `false`<br>
+**Description**: Whether to enable mysql app check.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    mysql:
+      enabled: true
+```
+
+## **agent.appChecks.mysql.hostname**
+**Required**: `false`<br>
+**Description**: Name of the mySQL host that the agent should connect to.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    mysql:
+      hostname: mysql-service-url
+```
+
+## **agent.appChecks.mysql.user**
+**Required**: `false`<br>
+**Description**: The username of the MySQL user that the agent will use in communicating with MySQL.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    mysql:
+      user: mysql-user
+```
+
+## **agent.appChecks.mysql.password**
+**Required**: `false`<br>
+**Description**: The password of the MySQL user that the agent will use in communicating with MySQL.<br>
+**Options**: `true|false`<br>
+**Default**: `false`<br>
+**Example**:
+
+```yaml
+agent:
+  appChecks:
+    mysql:
+      password: mysql-password
+```
+
+## **agent.resources.limits.cpu**
+**Required**: `false`<br>
+**Description**:  The amount of cpu assigned to agent pods.<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 3      |
+| medium       | 5      |
+| large        | 8      |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    limits:
+      cpu: 2
+```
+
+## **agent.resources.limits.memory**
+**Required**: `false`<br>
+**Description**:  The amount of memory assigned to agent pods.<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | limits |
+| ------------ | ------ |
+| small        | 3Gi    |
+| medium       | 6Gi    |
+| large        | 10Gi   |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    limits:
+      memory: 2
+```
+
+## **agent.resources.requests.cpu**
+**Required**: `false`<br>
+**Description**:  The amount of cpu required to schedule agent pods.<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1        |
+| medium       | 3        |
+| large        | 5        |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    requests:
+      cpu: 2
+```
+
+## **agent.resources.requests.memory**
+**Required**: `false`<br>
+**Description**:  The amount of memory required to schedule agent pods.<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 1Gi      |
+| medium       | 3Gi      |
+| large        | 6Gi      |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    requests:
+      memory: 2
+```
+
+## **agent.resources.watchdog.max_memory_usage_mb**
+**Required**: `false`<br>
+**Description**:  The max amount of memory the dragent process can take. Units for this value are Megabytes(mb)<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 512      |
+| medium       | 1024     |
+| large        | 2048     |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    watchdog:
+      max_memory_usage_mb: 1024
+```
+
+## **agent.resources.watchdog.cointerface**
+**Required**: `false`<br>
+**Description**:  The max amount of memory cointerface is allowed to consume. Units for this value are Megabytes(mb). Cointerface is responsible for fetching k8s events from api server and also builds the relationship graph for all k8s objects. This can take up a lot of memory during startup and in large clusters.<br>
+**Options**:<br>
+**Default**:
+
+| cluster-size | requests |
+| ------------ | -------- |
+| small        | 512      |
+| medium       | 2048     |
+| large        | 4096     |
+
+**Example**:
+
+```yaml
+agent:
+  resources:
+    watchdog:
+      cointerface: 1024
+```
+
+## **sysdig.eventsForwarderEnabledIntegrations**
+**Required**: `false`<br>
+**Description**: List of enabled integrations, e.g. "MCM,QRADAR"<br>
+**Options**:<br>
+**Default**: ""<br>
+**Example**:
+
+```yaml
+sysdig:
+  eventsForwarderEnabledIntegrations: "MCM,QRADAR"
+```
+
+## **sysdig.scanningAnalysiscollectorConcurrentUploads**
+**Required**: `false`<br>
+**Description**: Number of concurrent uploads for Scanning Analysis Collector<br>
+**Options**:<br>
+**Default**: "5"<br>
+**Example**:
+
+```yaml
+sysdig:
+  scanningAnalysiscollectorConcurrentUploads: 5
+```
+
+## **sysdig.secure.scanning.veJanitor.cronjob**
+**Required**: `false`<br>
+**Description**: Cronjob schedule<br>
+**Options**:<br>
+**Default**: "0 0 * * *"<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    veJanitor:
+      cronjob: "5 0 * * *"
+```
+
+## **sysdig.secure.scanning.veJanitor.anchoreDBsslmode**
+**Required**: `false`<br>
+**Description**: Anchore db ssl mode. More info: https://www.postgresql.org/docs/9.1/libpq-ssl.html<br>
+**Options**:<br>
+**Default**: "disable"<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    veJanitor:
+      anchoreDBsslmode: "disable"
+```
+
+## **sysdig.secure.scanning.veJanitor.scanningDbEngine**
+**Required**: `false`<br>
+**Description**: which scanning database engine to use. <br>
+**Options**: mysql<br>
+**Default**: "mysql"<br>
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    veJanitor:
+      scanningDbEngine: "mysql"
+```

--- a/3.6.2/examples/README.md
+++ b/3.6.2/examples/README.md
@@ -1,0 +1,6 @@
+# Example values.yaml
+
+- [single-node values.yaml](single-node/values.yaml)
+- [openshift-with-hostpath values.yaml](openshift-with-hostpath/values.yaml)
+- [node-labels-and-taints values.yaml](node-labels-and-taints/values.yaml)
+- [elasticsearch-init-vmmaxmapcount_overlays_patch.yaml](elasticsearch-init-vmmaxmapcount/overlays/patch.yaml)

--- a/3.6.2/examples/elasticsearch-init-vmmaxmapcount/overlays/patch.yaml
+++ b/3.6.2/examples/elasticsearch-init-vmmaxmapcount/overlays/patch.yaml
@@ -1,0 +1,20 @@
+#This patchfile adds an initcontainer to ElasticSearch and sets vmmaxmap count in ES hosts
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sysdigcloud-elasticsearch
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: elasticsearch-init-vmmaxmapcount
+          image: quay.io/sysdig/elasticsearch:<CURRENT_ES_VERSION>
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - sysctl
+            - -w
+          args:
+            - vm.max_map_count=262144

--- a/3.6.2/examples/elasticsearch-init-vmmaxmapcount/values.yaml
+++ b/3.6.2/examples/elasticsearch-init-vmmaxmapcount/values.yaml
@@ -1,0 +1,11 @@
+apps: monitor
+schema_version: 1.0.0
+size: small
+quaypullsecret: <PLEASE_REPLACE>
+storageClassProvisioner: aws
+sysdig:
+  ingressNetworking: loadbalancer
+  admin:
+    username: foo@bar.com
+  license: <PLEASE_REPLACE>
+  dnsName: foo.bar

--- a/3.6.2/examples/node-labels-and-taints/values.yaml
+++ b/3.6.2/examples/node-labels-and-taints/values.yaml
@@ -1,0 +1,52 @@
+# Node labels and node taints can be combined to ensure only Sysdig platform pods run on a particular node, the example below show starting from the `tolerations` sections shows how to configure the installer to take advantage of labels and tolerations.
+size: medium
+# Replace with quay.io pull secrets provided by the sales team.
+quaypullsecret: <PLEASE_REPLACE>
+# Acceptable values here are awe|gke|none|hostPath, change this to none and configure storageClassName if you want to use an existing storageClass
+storageClassProvisioner: hostPath
+# Uncomment the below to specify an existing storageClass, if not configured a storageClass is created with the configured storageClassProvisioner
+# storageClassName: sysdig
+elasticsearch:
+  hostPathNodes:
+    # replace with the name section of kubectl get nodes
+    - my-awesome-node01
+    - my-awesome-node02
+    - my-awesome-node03
+sysdig:
+  mysql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-awesome-node01
+  postgresql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-awesome-node01
+  cassandra:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-awesome-node01
+      - my-awesome-node02
+      - my-awesome-node03
+  # Replace with domain name the api should be served on.
+  dnsName: <PLEASE_REPLACE>
+  admin:
+    username: pov@sysdig.com
+  # Replace with license provided by the sales team.
+  license: <PLEASE_REPLACE>
+
+  # Everything below here is the core piece of this configuration.
+
+  # Nodes needs to have been assigned the taint dedicated=sysdig:NoSchedule, e.g:
+  # kubectl taint my-awesome-node01 dedicated=sysdig:NoSchedule
+  # for the below to work.
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: sysdig
+      effect: "NoSchedule"
+# Nodes needs to have been assigned labels role=sysdig for the below to work
+# e.g: kubectl label nodes my-awesome-node01 role=sysdig
+# for the below to work.
+nodeaffinityLabel:
+  key: role
+  value: sysdig

--- a/3.6.2/examples/openshift-with-hostpath/values.yaml
+++ b/3.6.2/examples/openshift-with-hostpath/values.yaml
@@ -1,0 +1,44 @@
+size: medium
+# The below can be ignored for non-openshift clusters.
+deployment: openshift
+# Replace with quay.io pull secrets provided by the sales team.
+quaypullsecret: <PLEASE_REPLACE>
+# Acceptable values here are awe|gke|none|hostPath, change this to none and configure storageClassName if you want to use an existing storageClass
+storageClassProvisioner: hostPath
+# Uncomment the below to specify an existing storageClass, if not configured a storageClass is created with the configured storageClassProvisioner
+# storageClassName: sysdig
+elasticsearch:
+  hostPathNodes:
+    # replace with the name section of kubectl get nodes
+    - my-cool-host1.com
+    - my-cool-host2.com
+    - my-cool-host3.com
+sysdig:
+  # Openshift API url along with its port number
+  openshiftUrl: <REPLACE_WITH_OPENSHIFT_URL>
+  # Username of the user to access the configured openshift url
+  openshiftUser: <REPLACE_WITH_OPENSHIFT_USERNAME>
+  # Password of the user to access the configured openshift url
+  openshiftPassword: <REPLACE_WITH_OPENSHIFT_PASSWORD>
+  collector:
+    dnsName: <PLEASE_REPLACE>
+  mysql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-cool-host1.com
+  postgresql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-cool-host1.com
+  cassandra:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - my-cool-host1.com
+      - my-cool-host2.com
+      - my-cool-host3.com
+  # Replace with domain name the api should be served on.
+  dnsName: <PLEASE_REPLACE>
+  admin:
+    username: <REPLACE_WITH_A_VALID_EMAIL_ADDRESS>
+  # Replace with license provided by the sales team.
+  license: <PLEASE_REPLACE>

--- a/3.6.2/examples/single-node/values.yaml
+++ b/3.6.2/examples/single-node/values.yaml
@@ -1,0 +1,53 @@
+# The instructions here should create Sysdig Platform on a single node with 8 cores and 16Gig of RAM.
+size: small
+# Replace with quay.io pull secrets provided by the sales team.
+quaypullsecret: <PLEASE_REPLACE>
+# Acceptable values here are awe|gke|none|hostPath, change this to none and configure storageClassName if you want to use an existing storageClass
+storageClassProvisioner: hostPath
+# Uncomment the below to specify an existing storageClass, if not configured a storageClass is created with the configured storageClassProvisioner
+# storageClassName: sysdig
+elasticsearch:
+  hostPathNodes:
+      # replace with the name section of kubectl get nodes
+    - minikube
+sysdig:
+  mysql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - minikube
+  postgresql:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - minikube
+  cassandra:
+    hostPathNodes:
+      # replace with the name section of kubectl get nodes
+      - minikube
+  # Replace with domain name the api should be served on.
+  dnsName: <PLEASE_REPLACE>
+  admin:
+    username: pov@sysdig.com
+  # Replace with license provided by the sales team.
+  license: <PLEASE_REPLACE>
+  # For PoC do not change the below
+  resources:
+    api:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+    cassandra:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+    collector:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+    elasticsearch:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+    worker:
+      requests:
+        cpu: 500m
+        memory: 1Gi

--- a/3.6.2/permissions.md
+++ b/3.6.2/permissions.md
@@ -1,0 +1,23 @@
+# Permissions
+
+## General
+* CRU on the sysdig namespace
+* CRU on StorageClass (only Read is required if the storageClass already exists)
+* CRUD on Secrets/ServiceAccount/ConfigMap/Deployment/CronJob/Job/StatefulSet/Service/DaemonSet in the sysdig namespace.
+* CRUD on role/rolebinding in sysdig namespace (if sysdig ingress controller is deployed)
+* CRU on the ingress-controller(this is the name of the object) ClusterRole/ClusterRoleBinding (if sysdig ingress controller is deployed)
+* Get Nodes (for validations).
+
+## MultiAZ enabled
+* CRU on the node-labels-to-files(this is the name of the object) ClusterRole/ClusterRoleBinding (for multi-AZ deployments)
+
+## HostPath
+* CRU on PV
+* CRU on PVC in sysdig namespace
+
+## Openshift
+* CRUD on route in the sysdig namespace
+* CRUD on openshift SCC in the sysdig namespace
+
+## Network policies enabled
+* CRUD on networkpolicies in sysdig namespace (if networkpolicies are enabled, this is an alpha feature customers should not enable it)

--- a/3.6.2/release_notes.md
+++ b/3.6.2/release_notes.md
@@ -47,6 +47,6 @@ Qualified with agent release 10.7.0
 
 | **sha256sum** | **Installer binary ** |
 |---|---|
-| | installer-darwin-amd64 |
-| | installer-linux-amd64 |
-| | installer-windows-amd64.exe |
+| f4febbebb9bfc87b3ee393d5c4b641955c7f61419ec97b9180dd939b4a3c02a2 | installer-darwin-amd64 |
+| 2ff1c7fcac37ec58f5a424d2ff62d9cee4c72e4c644dd73ecdfd3c8f7b1cd511 | installer-linux-amd64 |
+| 476acaf9badaf9860677661160efb01c1bce37000e744d0102d02fd5387c7946 | installer-windows-amd64.exe |

--- a/3.6.2/release_notes.md
+++ b/3.6.2/release_notes.md
@@ -1,0 +1,52 @@
+Release 3.6.2 December 14, 2020
+===
+
+Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html.
+
+Upgrade Matrix
+---
+
+Sysdig Platform version 3.6.2 has been tested and qualified against the following:
+
+Supported Upgrade From: 3.2.2, 3.5.1, (3.6.0 or 3.6.1 if it was installed)
+
+### Supported Platforms
+
+| **Platform** | **Version** |
+|---|---|
+| Vanilla Kubernetes          | 1.13.4, 14.10, 1.15.12, 1.16.13, 1.17.9, 1.18.6 |
+| OpenShift                   | 3.11, 4.4 |
+| GKE                         |1.14.10-gke.36 |
+| EKS                         |v1.17.7-eks-bffbac|
+| Rancher                     | v2.3.3|
+| IBM                         | Unqualified |
+| PKS                         | Unqualified |
+
+### Sysdig Agent Version
+
+Qualified with agent release 10.7.0
+
+### Supported Backend Components
+
+| **Components** | **Kubernetes with Statefulsets** |
+|---|---|
+| Redis                      | 4.0.12 |
+| MySQL                      | 5.6.44, 8.0.16|
+| MySQL HA                   | 8.0.16 |
+| ElasticSearch              | 6.8.6 |
+| Cassandra                  | release_version: 2.1.21 cql_version: 3.2.1 |
+| RDS                        | 8.0.16 |
+| Postgres (image scanning)  | 12.4|
+| Anchore (image scanning)   | 0.8.1 |
+| NATS Exporter              | 0.6.0.1 |
+| NATS Streaming             | 0.17.0 |
+| HA Proxy                   | 0.6.2|
+
+
+### Installer binaries sha256sum
+
+| **sha256sum** | **Installer binary ** |
+|---|---|
+| | installer-darwin-amd64 |
+| | installer-linux-amd64 |
+| | installer-windows-amd64.exe |

--- a/3.6.2/upgrade_notes.md
+++ b/3.6.2/upgrade_notes.md
@@ -1,0 +1,46 @@
+# Upgrade
+
+## Overview
+
+From version 3.5.0, both installing and upgrading with the installer has been simplified. Upgrade differs from Install in that you run an installer diff to discover the differences between the old and new versions and then installer deploy for the new version.
+
+Some guidance from Sysdig Support may be warranted in highly customized installations. 
+
+Refer to the appropriate workflow, depending on your environment:
+
+  - [Quickstart Install](README.md#quickstart-install)
+  - [Airgapped Installation Options](README.md#airgapped-installation-options)
+
+## Upgrade Notes
+
+### Elastic search 6.8.6 upgrade
+
+With Sysdig 3.6.2 install, ElasticSearch(ES) runs `privileged: false` by default. In most cases this should work automatically.
+
+There are some cases where ElasticSearch will fail with an error like below
+
+```bash
+kubectl -n sysdig logs -f sysdigcloud-elasticsearch-0
+...
++ grep cap_sys_admin
+++ sysctl -nb vm.max_map_count
++ max_map_count=65530
++ [[ 65530 -ne 262144 ]]
++ echo 'sysctl vm.max_map_count is not set to the correct value, and I do not have the privileges to set it!'
++ exit 1
+sysctl vm.max_map_count is not set to the correct value, and I do not have the privileges to set it!
+```
+
+There are 2 ways to fix this issue
+
+1. run systemctl command on hosts that run ElasticSearch,
+
+    ```bash
+    VM_MAX_MAP_COUNT=${VM_MAX_MAP_COUNT:-262144}; sysctl -w vm.max_map_count=${VM_MAX_MAP_COUNT}
+    ```
+
+2. An initContainer which runs as `privileged: true` and `root` and set vm.max_map_count [example overlay](examples/elasticsearch-init-vmmaxmapcount)
+
+## Release Notes
+
+- See [Release Notes](release_notes.md) for upgrade matrix, supported platforms & link to full feature notes

--- a/3.6.2/values.yaml
+++ b/3.6.2/values.yaml
@@ -1,0 +1,23 @@
+#This represents the schema version of this config, this version follows semver
+#and maintains semver guarantees around versioning.
+schema_version: 1.0.0
+#Size of the cluster. Takes [ small | medium | large ]
+#This defines CPU & Memory & Disk & Replicas
+#Replicas can be overwritten for medium , large in advanced   config section
+size: medium
+#Set Quay.Io secrets
+quaypullsecret: <change-me>
+#supports aws | gke | ibm | hostPath | local
+storageClassProvisioner: aws  # TODO: this would be better as cloudProvisioner | hostPath | local, where cloudProvisioner differs to cloudProvider.name where used
+#Sysdig application config
+sysdig:
+# Sysdig Platform super admin user. This will be used for initial login to
+# the web interface. Make sure this is a valid email address that you can
+# receive emails at.
+  admin:
+    username: <a-valid-email-address>
+  #Set Sysdig license
+  license: <change-me>
+  dnsName: <change-me>
+  #supports hostnetwork | loadbalancer | nodeport
+  ingressNetworking: hostnetwork

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In general, Sysdig tests and supports direct upgrade from **five releases** back
 
 |Install version | Included Hotfixes | Supported Upgrade From | Notes | Baseline Documentation |
 |---|---|---|---|---|
+| [3.6.2 (by request)](3.6.2)| | 3.2.x, 3.5.x, (3.6.0 or 3.6.1 if it was installed) | [3.6.2](https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html) | [3.6.2](3.6.2)
 | [3.6.1 (by request)](3.6.1)| | 3.2.x, 3.5.x, (3.6.0 if it was installed) | [3.6.1](https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html) | [3.6.1](3.6.1)
 | [3.6.0 (by request)](3.6.0)| | 3.2.x, 3.5.x | [3.6.0](https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html) | [3.6.0](3.6.0)
 


### PR DESCRIPTION
```bash
% diff 3.6.1 3.6.2
diff 3.6.1/README.md 3.6.2/README.md
240c240
<       docker pull quay.io/sysdig/installer:3.6.1-1-uber
---
>       docker pull quay.io/sysdig/installer:3.6.2-1-uber
244c244
<       docker create --name uber_image quay.io/sysdig/installer:3.6.1-1-uber
---
>       docker create --name uber_image quay.io/sysdig/installer:3.6.2-1-uber
253c253
<       wget https://github.com/draios/onprem-install-docs/blob/main/3.6.1/values.yaml
---
>       wget https://github.com/draios/onprem-install-docs/blob/main/3.6.2/values.yaml
diff 3.6.1/configuration_parameters.md 3.6.2/configuration_parameters.md
678c678
<   activityAuditVersion: 3.6.1.7758
---
>   activityAuditVersion: 3.6.2.7998
690c690
<   profilingVersion: 3.6.1.7758
---
>   profilingVersion: 3.6.2.7998
1132c1132
< **Default**: 3.6.1.7758<br>
---
> **Default**: 3.6.2.7998<br>
1137c1137
<   monitorVersion: 3.6.1.7758
---
>   monitorVersion: 3.6.2.7998
1147c1147
< **Default**: 3.6.1.7758<br>
---
> **Default**: 3.6.2.7998<br>
1152c1152
<   scanningVersion: 3.6.1.7758
---
>   scanningVersion: 3.6.2.7998
1162c1162
< **Default**: 3.6.1.7758<br>
---
> **Default**: 3.6.2.7998<br>
1167c1167
<   sysdigAPIVersion: 3.6.1.7758
---
>   sysdigAPIVersion: 3.6.2.7998
1177c1177
< **Default**: 3.6.1.7758<br>
---
> **Default**: 3.6.2.7998<br>
1182c1182
<   sysdigCollectorVersion: 3.6.1.7758
---
>   sysdigCollectorVersion: 3.6.2.7998
1192c1192
< **Default**: 3.6.1.7758<br>
---
> **Default**: 3.6.2.7998<br>
1197c1197
<   sysdigWorkerVersion: 3.6.1.7758
---
>   sysdigWorkerVersion: 3.6.2.7998
Common subdirectories: 3.6.1/examples and 3.6.2/examples
diff 3.6.1/release_notes.md 3.6.2/release_notes.md
1c1
< Release 3.6.1 November 23, 2020
---
> Release 3.6.2 December 14, 2020
9c9
< Sysdig Platform version 3.6.1 has been tested and qualified against the following:
---
> Sysdig Platform version 3.6.2 has been tested and qualified against the following:
11c11
< Supported Upgrade From: 3.2.2, 3.5.1, (3.6.0 if it was installed)
---
> Supported Upgrade From: 3.2.2, 3.5.1, (3.6.0 or 3.6.1 if it was installed)
27c27
< Qualified with agent release 10.6.0
---
> Qualified with agent release 10.7.0
50,52c50,52
< | e9796aca513c30de5f7a082f28bed354ebff798ad9be2ff0721cbe9075d69657 | installer-darwin-amd64 |
< | e62f840e46aabcd616261ad8224714142707e275bcd3d49c7754483cf65cd1df | installer-linux-amd64 |
< | 3347b8f6d728e88b2d36ca2ce1402929af3b2f9d292dd490e9187f94f41fc851 | installer-windows-amd64.exe |
---
> | f4febbebb9bfc87b3ee393d5c4b641955c7f61419ec97b9180dd939b4a3c02a2 | installer-darwin-amd64 |
> | 2ff1c7fcac37ec58f5a424d2ff62d9cee4c72e4c644dd73ecdfd3c8f7b1cd511 | installer-linux-amd64 |
> | 476acaf9badaf9860677661160efb01c1bce37000e744d0102d02fd5387c7946 | installer-windows-amd64.exe |
diff 3.6.1/upgrade_notes.md 3.6.2/upgrade_notes.md
18c18
< With Sysdig 3.6.1 install, ElasticSearch(ES) runs `privileged: false` by default. In most cases this should work automatically.
---
> With Sysdig 3.6.2 install, ElasticSearch(ES) runs `privileged: false` by default. In most cases this should work automatically.
```