### PR TITLE
Fix checksums for 4.0.5 and 5.0.2 installer binaries

### DIFF
--- a/4.0.5/release_notes.md
+++ b/4.0.5/release_notes.md
@@ -44,6 +44,6 @@ Current version: 4.0.5-1
 
 | **sha256sum** | **Installer binary ** |
 |---|---|
-| 6ffd8d883a80ea6984b6aa160e2c61a73ec6234821b3b026545534db28427fb3 | installer-darwin-amd64 |
-| 5e35b610d98e9b6de6298cd547eee354bdda04e8d46a00062d087e47e214b329 | installer-linux-amd64 |
-| 55dc7ff7338c977ff9d01e85a7b2c815814adc8a2cebd1ff701941dfadb6df62 | installer-windows-amd64.exe |
+| cb8cb97f78fcc7c1829895b589616a910c3370efeedd0c14e3e7a9bb4cac2599 | installer-darwin-amd64 |
+| c805106d653c410c207eb9e481efc84241e0bc922dcf3d0f658aff2efae753d7 | installer-linux-amd64 |
+| 6b5c4628fa60b5ed27ae4e9e573de772e18b37dcde4cc8cb02f5d77723b990a9 | installer-windows-amd64.exe |

--- a/5.0.2/release_notes.md
+++ b/5.0.2/release_notes.md
@@ -44,6 +44,6 @@ Current version: 5.0.2
 
 | **sha256sum** | **Installer binary ** |
 |---|---|
-| 50f0c3bb44f7d065bc286d3b4a087a4fa2814e70cfa04dd930ac2e49089c1feb | installer-darwin-amd64 |
-| c0da8ac9cd93fd1476c4eea9d84d0c12d1622584059a724fcc438de02578641f | installer-linux-amd64 |
-| 3ce037f0f8747e28bc52879a7b95d21d2505161690d411eb80319bf052952df7 | installer-windows-amd64.exe |
+| b4764355bad9d9d8c1ef3b1294fcce00f18435ed7323d07dea652fe7404a59b7 | installer-darwin-amd64 |
+| f344008326ebc50ca0e57b7e378a1b9572de9cb5c4499091d29f18f6224c4a5d | installer-linux-amd64 |
+| 7555e5bea1eac1bd2dc3e8c8f74b86f1a46a16066c993fda7ceb85198712816a | installer-windows-amd64.exe |


### PR DESCRIPTION
I made a mistake in 4.0.5 and 5.0.2 releases, where I used the checksum of the installer release candidates, not the actual github releases. 

This PR is for setting the correct checksums.