### PR TITLE
Fix wget commands in Onprem install docs

### DIFF
--- a/3.6.0/README.md
+++ b/3.6.0/README.md
@@ -250,7 +250,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.0/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/3.6.0/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/3.6.1/README.md
+++ b/3.6.1/README.md
@@ -250,7 +250,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.1/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/3.6.1/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/3.6.2/README.md
+++ b/3.6.2/README.md
@@ -250,7 +250,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.2/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/3.6.2/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/3.6.3/README.md
+++ b/3.6.3/README.md
@@ -250,7 +250,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.3/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/3.6.3/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/3.6.4/README.md
+++ b/3.6.4/README.md
@@ -250,7 +250,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/3.6.4/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/3.6.4/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.0/README.md
+++ b/4.0.0/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.0/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.0/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.1/README.md
+++ b/4.0.1/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.1/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.1/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.2/README.md
+++ b/4.0.2/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.2/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.2/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.3/README.md
+++ b/4.0.3/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.3/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.3/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.4/README.md
+++ b/4.0.4/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.4/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.4/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.5/README.md
+++ b/4.0.5/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.5/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.5/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.6/README.md
+++ b/4.0.6/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.5/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.5/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/4.0.7/README.md
+++ b/4.0.7/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/4.0.7/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/4.0.7/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/5.0.0/README.md
+++ b/5.0.0/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.0/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/5.0.0/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/5.0.1/README.md
+++ b/5.0.1/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.1/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/5.0.1/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/5.0.2/README.md
+++ b/5.0.2/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.2/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/5.0.2/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/5.0.3/README.md
+++ b/5.0.3/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.3/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/5.0.3/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/5.0.4/README.md
+++ b/5.0.4/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.4/values.yaml
+      wget https://raw.githubusercontent.com/draios/onprem-install-docs/blob/main/5.0.4/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size


### PR DESCRIPTION
One of my team members noted that using this wget command is not working:
wget https://github.com/draios/onprem-install-docs/blob/main/5.0.4/values.yaml

However this does work:
wget https://raw.githubusercontent.com/draios/onprem-install-docs/main/5.0.4/values.yaml

Please verify, and merge if this makes sense to change. Thanks!