### PR TITLE
Add global K8s support matrix

### DIFF
--- a/6.X/6.0.1/release_notes.md
+++ b/6.X/6.0.1/release_notes.md
@@ -3,23 +3,6 @@ Release 6.0.1 April, 2023
 
 Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html.
 
-Upgrade Matrix
----
-
-Sysdig Platform version 6.0.1 has been tested and qualified against the following:
-
-Supported Upgrade From: Not yet supported
-
-### Supported Platforms
-
-| **Platform** | **Version** |
-|---|---|
-| Vanilla Kubernetes          | 1.21.14, 1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3 |
-| OpenShift                   | 4.10, 4.11, 4.12 |
-| GKE                         | v1.24.9-gke.3200 |
-| EKS                         | 1.22 |
-| Rancher                     | 2.5.7 |
-
 ### Sysdig Agent Version
 
 Qualified with agent release 11.4.1

--- a/6.X/6.0.2/release_notes.md
+++ b/6.X/6.0.2/release_notes.md
@@ -3,23 +3,6 @@ Release 6.0.2 April, 2023
 
 Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html.
 
-Upgrade Matrix
----
-
-Sysdig Platform version 6.0.2 has been tested and qualified against the following:
-
-Supported Upgrade From: Not yet supported
-
-### Supported Platforms
-
-| **Platform** | **Version** |
-|---|---|
-| Vanilla Kubernetes          | 1.21.14, 1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3 |
-| OpenShift                   | 4.10, 4.11, 4.12 |
-| GKE                         | v1.24.9-gke.3200 |
-| EKS                         | 1.22 |
-| Rancher                     | 2.5.7 |
-
 ### Sysdig Agent Version
 
 Qualified with agent release 11.4.1

--- a/6.X/6.1.1/release_notes.md
+++ b/6.X/6.1.1/release_notes.md
@@ -3,22 +3,6 @@ Release 6.1.1 May, 2023
 
 Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html.
 
-Upgrade Matrix
----
-
-Sysdig Platform version 6.1.1 has been tested and qualified against the following:
-
-Supported Upgrade From: 5.0.X, 5.1.x, 6.0.x
-
-### Supported Platforms
-
-| **Platform** | **Version** |
-|---|---|
-| Vanilla Kubernetes          | 1.21.14, 1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3 |
-| OpenShift                   | 4.10, 4.11, 4.12 |
-| GKE                         | v1.24.9-gke.3200 |
-| EKS                         | 1.22 |
-
 ### Sysdig Agent Version
 
 Qualified with agent release 11.4.1

--- a/6.X/6.1.2/release_notes.md
+++ b/6.X/6.1.2/release_notes.md
@@ -3,22 +3,6 @@ Release 6.1.2 May, 2023
 
 Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on-premises-release-notes.html.
 
-Upgrade Matrix
----
-
-Sysdig Platform version 6.1.2 has been tested and qualified against the following:
-
-Supported Upgrade From: 5.0.X, 5.1.x, 6.0.x
-
-### Supported Platforms
-
-| **Platform** | **Version** |
-|---|---|
-| Vanilla Kubernetes          | 1.21.14, 1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3 |
-| OpenShift                   | 4.10, 4.11, 4.12 |
-| GKE                         | v1.24.9-gke.3200 |
-| EKS                         | 1.22 |
-
 ### Sysdig Agent Version
 
 Qualified with agent release 11.4.1

--- a/6.X/6.2.1/release_notes.md
+++ b/6.X/6.2.1/release_notes.md
@@ -5,20 +5,6 @@ Review the full feature release notes here: https://docs.sysdig.com/en/sysdig-on
 
 Note: 6.2.1 release introduces the new ScanningV2 engine, which still does not qualifies for air-gap environments.
 
-Upgrade Matrix
----
-
-Supported Upgrade From: 5.0.X, 5.1.x, 6.0.x, 6.1.x
-
-### Supported Platforms
-
-| **Platform** | **Version** |
-|---|---|
-| Vanilla Kubernetes          | 1.21.14, 1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3 |
-| OpenShift                   | 4.10, 4.11, 4.12 |
-| GKE                         | v1.24.9-gke.3200 |
-| EKS                         | 1.22 |
-
 ### Sysdig Agent Version
 
 Qualified with agent release 11.4.1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sysdig platform is continuosly being validated at multiple K8s flavors including
 |---|---|
 | 5.0.X | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
 | 5.1.X | 1.18, 1.19, 1.20, 1.21, 1.22, 1.23, 1.24 |
-| 6.X | 1.23, 1.24, 1.25, 1.16, 1.27 |
+| 6.X | 1.23, 1.24, 1.25, 1.16 |
 
 ## Supported Migration Paths
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sysdig platform is continuosly being validated at multiple K8s flavors including
 |---|---|
 | 5.0.X | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
 | 5.1.X | 1.18, 1.19, 1.20, 1.21, 1.22, 1.23, 1.24 |
-| 6.X | 1.23, 1.24, 1.25, 1.16 |
+| 6.X | 1.23, 1.24, 1.25, 1.26 |
 
 ## Supported Migration Paths
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Beyond info at this repo, take a look to our [Sysdig On-Premises Release Notes](
 
 |Install version | Supported Upgrade From | Latest Release |
 |---|---|---|
-| 6.x (by request) | 4.0.X, 5.0.X, 5.1.X 6.X.X (to 6.1.1 and above) | [6.1.1](6.X/6.1.1) |
+| 6.x (by request) | 5.0.X, 5.1.X 6.X.X | [6.X](6.X) |
 | 5.1 (by request) | 4.0.X, 5.0.X, 5.1.X | [5.1](5.1) |
 | 5.0 (by request) | 4.0.X, 5.0.X | [5.0](5.0) |
 | 4.0 (by request) | 3.6.X, 4.0.X | [4.0](4.0) |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The Sysdig Platform is a highly available application for securing and monitorin
 >
 > If you are a new customer looking to explore Sysdig, please head over [here](https://sysdig.com/company/freetrial/) to sign up for a trial on our SaaS Platform. Alternatively, you can contact us [here](https://sysdig.com/company/contactus/).
 
+## K8s support matrix
+
+Sysdig platform is continuosly being validated at multiple K8s flavors including k0ps, Openshift4, EKS, GKE, AKS, IKS, ROKS or RKE2. You can find below the K8s version support matrix. If you might have a question about a custom flavor or K8s version, please just share it with your TAM.
+
+| Install version | Validated K8s versions |
+|---|---|
+| 5.0.X | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
+| 5.1.X | 1.18, 1.19, 1.20, 1.21, 1.22, 1.23, 1.24 |
+| 6.X | 1.23, 1.24, 1.25, 1.16, 1.27 |
+
 ## Supported Migration Paths
 
 In general, Sysdig tests and supports direct upgrade from **two releases** back to the current version.


### PR DESCRIPTION
Because of the new releases flow, I am moving the K8s support matrix from every release to a global and clearer table. Though we test in-house multiple k8s flavors, I am removing individual flavor versions because they do not reflex our actual flavor version support.

I am also fixing 6.X upgrade path global table.