### PR TITLE
[QA-7829] Update 6.4.0 values.yaml reference

### DIFF
--- a/6.X/6.4.0/README.md
+++ b/6.X/6.4.0/README.md
@@ -249,7 +249,7 @@ docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 #### On the Installation Machine:
 1. Copy the current version sysdig-chart/values.yaml to your working directory.
       ```bash
-      wget https://github.com/draios/onprem-install-docs/blob/main/5.0.4/values.yaml
+      wget https://github.com/draios/onprem-install-docs/blob/main/6.X/6.4.0/examples/values.yaml
       ```
 2. Edit the following values:
       - [`size`](configuration_parameters.md#size): Specifies the size of the cluster. Size

--- a/6.X/6.4.0/examples/values.yaml
+++ b/6.X/6.4.0/examples/values.yaml
@@ -1,0 +1,24 @@
+#This represents the schema version of this config, this version follows semver
+#and maintains semver guarantees around versioning.
+schema_version: 1.0.0
+#Size of the cluster. Takes [ small | medium | large ]
+#This defines CPU & Memory & Disk & Replicas
+#Replicas can be overwritten for medium , large in advanced   config section
+size: medium
+#Set Quay.Io secrets
+quaypullsecret: <change-me>
+#supports aws | gke | ibm | hostPath | local
+storageClassProvisioner: aws  # TODO: this would be better as cloudProvisioner | hostPath | local, where cloudProvisioner differs to cloudProvider.name where used
+#Sysdig application config
+sysdig:
+# Sysdig Platform super admin user. This will be used for initial login to
+# the web interface. Make sure this is a valid email address that you can
+# receive emails at.
+  admin:
+    username: <a-valid-email-address>
+  #Set Sysdig license
+  license: <change-me>
+  dnsName: <change-me>
+  #supports hostnetwork | loadbalancer | nodeport
+  ingressNetworking: hostnetwork
+  ingressClassName: haproxy


### PR DESCRIPTION
This PR updates 6.4.0 READ.ME values.yaml link since it was still pointing to 5.0.4. The values.yaml file was obtained from https://github.com/draios/installer/blob/onprem-6-4-0/sysdig-chart/values.yaml

Originated from: https://sysdig.atlassian.net/browse/QA-7829