### PR TITLE
Fix event audit ip documentation for 6.14.1

### DIFF
--- a/6.X/6.14.1/README.md
+++ b/6.X/6.14.1/README.md
@@ -58,7 +58,7 @@ This install assumes the Kubernetes cluster has network access to pull images fr
     provided with your Sysdig purchase confirmation mail
   - [`sysdig.platformAuditTrail.enabled`](docs/02-configuration_parameters.md#sysdigplatformAuditTrailenabled):
     Set this parameter to `true` if you would like to use Sysdig Platform Audit.
-  - [`sysdig.secure.events.audit.config.store.ip.enabled`](docs/02-configuration_parameters.md#sysdigsecureeventsauditconfigstoreipenabled):
+  - [`sysdig.secure.events.audit.config.store.ip`](docs/02-configuration_parameters.md#sysdigsecureeventsauditconfigstoreipenabled):
   	Set this parameter to `true` if you would like to see the origin IP address in Sysdig Platform Audit.
   - [`sysdig.dnsName`](docs/02-configuration_parameters.md#sysdigdnsName): The domain name
     the Sysdig APIs will be served on.


### PR DESCRIPTION
- The sysdig.secure.events.audit.config.store.ip is the correct path, fixed already in 6.14.0, moving the change to 6.14.1 as well.