### PR TITLE
feat(docs): Adding docs for scanrslts db retention configuration

### DIFF
--- a/7.X/7.0.0/docs/02-configuration_parameters.md
+++ b/7.X/7.0.0/docs/02-configuration_parameters.md
@@ -14006,6 +14006,40 @@ sysdig:
           timeout: "30s"
 ```
 
+## **sysdig.secure.scanningv2.scanResultAPI.partman.retention.pipeline**
+**Required**: `false`<br />
+**Description**: The retention period in days for pipeline results in the scan results database. Acceptable values range from 1 to 90.<br />
+**Default**: `90`<br />
+
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanningv2:
+      scanResultAPI:
+        partman:
+          retention:
+            pipeline: "90"
+```
+
+## **sysdig.secure.scanningv2.scanResultAPI.partman.retention.registry**
+**Required**: `false`<br />
+**Description**: The retention period in days for registry results in the scan results database. Acceptable values range from 1 to 90. <br/>
+**Default**: `90`<br />
+
+**Example**:
+
+```yaml
+sysdig:
+  secure:
+    scanningv2:
+      scanResultAPI:
+        partman:
+          retention:
+            registry: "90"
+```
+
 ## **sysdig.platformService.enabled**
 
 **Required**: `false`<br />


### PR DESCRIPTION
This pull request includes updates to the `7.X/7.0.0/docs/02-configuration_parameters.md` file to add new configuration parameters for `sysdig.secure.scanningv2.scanResultAPI.partman.retention`. The changes introduce new sections for defining retention periods for pipeline and registry results in the scan results database.

Documentation updates:

* Added `sysdig.secure.scanningv2.scanResultAPI.partman.retention.pipeline` parameter with a description, default value, and example configuration.
* Added `sysdig.secure.scanningv2.scanResultAPI.partman.retention.registry` parameter with a description, default value, and example configuration.